### PR TITLE
Update serialization tests for java 8 compatibility

### DIFF
--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/CollectionSerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/CollectionSerializationTest.java
@@ -2,6 +2,7 @@ package com.ijioio.aes.sandbox.test;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Month;
 import java.util.ArrayList;
@@ -38,10 +39,14 @@ public class CollectionSerializationTest {
 		public static final String NAME = "com.ijioio.test.model.CollectionSerialization";
 	}
 
+	private Path path;
+
 	private CollectionSerialization model;
 
 	@BeforeEach
-	public void before() {
+	public void before() throws Exception {
+
+		path = Paths.get(getClass().getClassLoader().getResource("collection-serialization.xml").toURI());
 
 		ArrayList<String> stringList = new ArrayList<>(Arrays.asList("value1", "value2", "value3"));
 		ArrayList<Month> enumList = new ArrayList<>(Arrays.asList(Month.JANUARY, Month.FEBRUARY, Month.MARCH));
@@ -68,10 +73,7 @@ public class CollectionSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		String actual = XmlUtil.write(handler, model);
-		String expected = new String(
-				Files.readAllBytes(
-						Paths.get(getClass().getClassLoader().getResource("collection-serialization.xml").toURI())),
-				StandardCharsets.UTF_8);
+		String expected = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
 
 		Assertions.assertEquals(expected, actual);
 	}
@@ -81,10 +83,8 @@ public class CollectionSerializationTest {
 
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
-		CollectionSerialization actual = XmlUtil.read(handler, CollectionSerialization.class, new String(
-				Files.readAllBytes(
-						Paths.get(getClass().getClassLoader().getResource("collection-serialization.xml").toURI())),
-				StandardCharsets.UTF_8));
+		CollectionSerialization actual = XmlUtil.read(handler, CollectionSerialization.class,
+				new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
 		CollectionSerialization expected = model;
 
 		Assertions.assertEquals(expected.getId(), actual.getId());

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/CollectionSerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/CollectionSerializationTest.java
@@ -1,5 +1,6 @@
 package com.ijioio.aes.sandbox.test;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Month;
@@ -32,7 +33,6 @@ public class CollectionSerializationTest {
 					@EntityProperty(name = "valueObjectSet", type = @Type(name = Type.SET), parameters = @Type(name = "java.lang.Object")) //
 			} //
 	)
-
 	public static interface CollectionSerializationPrototype {
 
 		public static final String NAME = "com.ijioio.test.model.CollectionSerialization";
@@ -68,9 +68,10 @@ public class CollectionSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		String actual = XmlUtil.write(handler, model);
-		Files.writeString(Paths.get("c://deleteme/collection-serialization.xml"), actual);
-		String expected = Files
-				.readString(Paths.get(getClass().getClassLoader().getResource("collection-serialization.xml").toURI()));
+		String expected = new String(
+				Files.readAllBytes(
+						Paths.get(getClass().getClassLoader().getResource("collection-serialization.xml").toURI())),
+				StandardCharsets.UTF_8);
 
 		Assertions.assertEquals(expected, actual);
 	}
@@ -80,8 +81,10 @@ public class CollectionSerializationTest {
 
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
-		CollectionSerialization actual = XmlUtil.read(handler, CollectionSerialization.class, Files.readString(
-				Paths.get(getClass().getClassLoader().getResource("collection-serialization.xml").toURI())));
+		CollectionSerialization actual = XmlUtil.read(handler, CollectionSerialization.class, new String(
+				Files.readAllBytes(
+						Paths.get(getClass().getClassLoader().getResource("collection-serialization.xml").toURI())),
+				StandardCharsets.UTF_8));
 		CollectionSerialization expected = model;
 
 		Assertions.assertEquals(expected.getId(), actual.getId());

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/EnumSerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/EnumSerializationTest.java
@@ -1,5 +1,6 @@
 package com.ijioio.aes.sandbox.test;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Month;
@@ -23,7 +24,6 @@ public class EnumSerializationTest {
 					@EntityProperty(name = "valueEnum", type = @Type(name = "java.time.Month")) //
 			} //
 	)
-
 	public static interface EnumSerializationPrototype {
 
 		public static final String NAME = "com.ijioio.test.model.EnumSerialization";
@@ -46,8 +46,10 @@ public class EnumSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		String actual = XmlUtil.write(handler, model);
-		String expected = Files
-				.readString(Paths.get(getClass().getClassLoader().getResource("enum-serialization.xml").toURI()));
+		String expected = new String(
+				Files.readAllBytes(
+						Paths.get(getClass().getClassLoader().getResource("enum-serialization.xml").toURI())),
+				StandardCharsets.UTF_8);
 
 		Assertions.assertEquals(expected, actual);
 	}
@@ -58,7 +60,10 @@ public class EnumSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		EnumSerialization actual = XmlUtil.read(handler, EnumSerialization.class,
-				Files.readString(Paths.get(getClass().getClassLoader().getResource("enum-serialization.xml").toURI())));
+				new String(
+						Files.readAllBytes(
+								Paths.get(getClass().getClassLoader().getResource("enum-serialization.xml").toURI())),
+						StandardCharsets.UTF_8));
 		EnumSerialization expected = model;
 
 		Assertions.assertEquals(expected.getId(), actual.getId());

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/EnumSerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/EnumSerializationTest.java
@@ -2,6 +2,7 @@ package com.ijioio.aes.sandbox.test;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Month;
 
@@ -29,10 +30,14 @@ public class EnumSerializationTest {
 		public static final String NAME = "com.ijioio.test.model.EnumSerialization";
 	}
 
+	private Path path;
+
 	private EnumSerialization model;
 
 	@BeforeEach
-	public void before() {
+	public void before() throws Exception {
+
+		path = Paths.get(getClass().getClassLoader().getResource("enum-serialization.xml").toURI());
 
 		model = new EnumSerialization();
 
@@ -46,10 +51,7 @@ public class EnumSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		String actual = XmlUtil.write(handler, model);
-		String expected = new String(
-				Files.readAllBytes(
-						Paths.get(getClass().getClassLoader().getResource("enum-serialization.xml").toURI())),
-				StandardCharsets.UTF_8);
+		String expected = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
 
 		Assertions.assertEquals(expected, actual);
 	}
@@ -60,10 +62,7 @@ public class EnumSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		EnumSerialization actual = XmlUtil.read(handler, EnumSerialization.class,
-				new String(
-						Files.readAllBytes(
-								Paths.get(getClass().getClassLoader().getResource("enum-serialization.xml").toURI())),
-						StandardCharsets.UTF_8));
+				new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
 		EnumSerialization expected = model;
 
 		Assertions.assertEquals(expected.getId(), actual.getId());

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/MapSerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/MapSerializationTest.java
@@ -1,5 +1,6 @@
 package com.ijioio.aes.sandbox.test;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Month;
@@ -30,7 +31,6 @@ public class MapSerializationTest {
 							@Type(name = "java.lang.Object"), @Type(name = "java.lang.Object") }) //
 			} //
 	)
-
 	public static interface MapSerializationPrototype {
 
 		public static final String NAME = "com.ijioio.test.model.MapSerialization";
@@ -72,8 +72,9 @@ public class MapSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		String actual = XmlUtil.write(handler, model);
-		String expected = Files
-				.readString(Paths.get(getClass().getClassLoader().getResource("map-serialization.xml").toURI()));
+		String expected = new String(
+				Files.readAllBytes(Paths.get(getClass().getClassLoader().getResource("map-serialization.xml").toURI())),
+				StandardCharsets.UTF_8);
 
 		Assertions.assertEquals(expected, actual);
 	}
@@ -84,7 +85,10 @@ public class MapSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		MapSerialization actual = XmlUtil.read(handler, MapSerialization.class,
-				Files.readString(Paths.get(getClass().getClassLoader().getResource("map-serialization.xml").toURI())));
+				new String(
+						Files.readAllBytes(
+								Paths.get(getClass().getClassLoader().getResource("map-serialization.xml").toURI())),
+						StandardCharsets.UTF_8));
 		MapSerialization expected = model;
 
 		Assertions.assertEquals(expected.getId(), actual.getId());

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/MapSerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/MapSerializationTest.java
@@ -2,6 +2,7 @@ package com.ijioio.aes.sandbox.test;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Month;
 import java.util.LinkedHashMap;
@@ -36,10 +37,14 @@ public class MapSerializationTest {
 		public static final String NAME = "com.ijioio.test.model.MapSerialization";
 	}
 
+	private Path path;
+
 	private MapSerialization model;
 
 	@BeforeEach
-	public void before() {
+	public void before() throws Exception {
+
+		path = Paths.get(getClass().getClassLoader().getResource("map-serialization.xml").toURI());
 
 		Map<String, String> stringMap = new LinkedHashMap<>();
 
@@ -72,9 +77,7 @@ public class MapSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		String actual = XmlUtil.write(handler, model);
-		String expected = new String(
-				Files.readAllBytes(Paths.get(getClass().getClassLoader().getResource("map-serialization.xml").toURI())),
-				StandardCharsets.UTF_8);
+		String expected = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
 
 		Assertions.assertEquals(expected, actual);
 	}
@@ -85,10 +88,7 @@ public class MapSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		MapSerialization actual = XmlUtil.read(handler, MapSerialization.class,
-				new String(
-						Files.readAllBytes(
-								Paths.get(getClass().getClassLoader().getResource("map-serialization.xml").toURI())),
-						StandardCharsets.UTF_8));
+				new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
 		MapSerialization expected = model;
 
 		Assertions.assertEquals(expected.getId(), actual.getId());

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/PrimitiveSerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/PrimitiveSerializationTest.java
@@ -2,6 +2,7 @@ package com.ijioio.aes.sandbox.test;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Assertions;
@@ -35,10 +36,14 @@ public class PrimitiveSerializationTest {
 		public static final String NAME = "com.ijioio.test.model.PrimitiveSerialization";
 	}
 
+	private Path path;
+
 	private PrimitiveSerialization model;
 
 	@BeforeEach
-	public void before() {
+	public void before() throws Exception {
+
+		path = Paths.get(getClass().getClassLoader().getResource("primitive-serialization.xml").toURI());
 
 		model = new PrimitiveSerialization();
 
@@ -59,10 +64,7 @@ public class PrimitiveSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		String actual = XmlUtil.write(handler, model);
-		String expected = new String(
-				Files.readAllBytes(
-						Paths.get(getClass().getClassLoader().getResource("primitive-serialization.xml").toURI())),
-				StandardCharsets.UTF_8);
+		String expected = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
 
 		Assertions.assertEquals(expected, actual);
 	}
@@ -72,10 +74,8 @@ public class PrimitiveSerializationTest {
 
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
-		PrimitiveSerialization actual = XmlUtil.read(handler, PrimitiveSerialization.class, new String(
-				Files.readAllBytes(
-						Paths.get(getClass().getClassLoader().getResource("primitive-serialization.xml").toURI())),
-				StandardCharsets.UTF_8));
+		PrimitiveSerialization actual = XmlUtil.read(handler, PrimitiveSerialization.class,
+				new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
 		PrimitiveSerialization expected = model;
 
 		Assertions.assertEquals(expected.getId(), actual.getId());

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/PrimitiveSerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/PrimitiveSerializationTest.java
@@ -1,5 +1,6 @@
 package com.ijioio.aes.sandbox.test;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -29,7 +30,6 @@ public class PrimitiveSerializationTest {
 					@EntityProperty(name = "valueDouble", type = @Type(name = Type.DOUBLE)) //
 			} //
 	)
-
 	public static interface PrimitiveSerializationPrototype {
 
 		public static final String NAME = "com.ijioio.test.model.PrimitiveSerialization";
@@ -59,8 +59,10 @@ public class PrimitiveSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		String actual = XmlUtil.write(handler, model);
-		String expected = Files
-				.readString(Paths.get(getClass().getClassLoader().getResource("primitive-serialization.xml").toURI()));
+		String expected = new String(
+				Files.readAllBytes(
+						Paths.get(getClass().getClassLoader().getResource("primitive-serialization.xml").toURI())),
+				StandardCharsets.UTF_8);
 
 		Assertions.assertEquals(expected, actual);
 	}
@@ -70,8 +72,10 @@ public class PrimitiveSerializationTest {
 
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
-		PrimitiveSerialization actual = XmlUtil.read(handler, PrimitiveSerialization.class, Files
-				.readString(Paths.get(getClass().getClassLoader().getResource("primitive-serialization.xml").toURI())));
+		PrimitiveSerialization actual = XmlUtil.read(handler, PrimitiveSerialization.class, new String(
+				Files.readAllBytes(
+						Paths.get(getClass().getClassLoader().getResource("primitive-serialization.xml").toURI())),
+				StandardCharsets.UTF_8));
 		PrimitiveSerialization expected = model;
 
 		Assertions.assertEquals(expected.getId(), actual.getId());

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/SkipSerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/SkipSerializationTest.java
@@ -2,6 +2,7 @@ package com.ijioio.aes.sandbox.test;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,10 +39,14 @@ public class SkipSerializationTest {
 		public static final String NAME = "com.ijioio.test.model.SkipSerialization";
 	}
 
+	private Path path;
+
 	private SkipSerialization model;
 
 	@BeforeEach
-	public void before() {
+	public void before() throws Exception {
+
+		path = Paths.get(getClass().getClassLoader().getResource("skip-serialization.xml").toURI());
 
 		ArrayList<String> stringList = new ArrayList<>(Arrays.asList("value1", "value2"));
 		Set<String> stringSet = new LinkedHashSet<>(Arrays.asList("value1", "value2"));
@@ -65,10 +70,7 @@ public class SkipSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		SkipSerialization actual = XmlUtil.read(handler, SkipSerialization.class,
-				new String(
-						Files.readAllBytes(
-								Paths.get(getClass().getClassLoader().getResource("skip-serialization.xml").toURI())),
-						StandardCharsets.UTF_8));
+				new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
 		SkipSerialization expected = model;
 
 		Assertions.assertEquals(expected.getId(), actual.getId());

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/SkipSerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/SkipSerializationTest.java
@@ -1,5 +1,6 @@
 package com.ijioio.aes.sandbox.test;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -32,7 +33,6 @@ public class SkipSerializationTest {
 							@Type(name = Type.STRING), @Type(name = Type.STRING) }) //
 			} //
 	)
-
 	public static interface SkipSerializationPrototype {
 
 		public static final String NAME = "com.ijioio.test.model.SkipSerialization";
@@ -65,7 +65,10 @@ public class SkipSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		SkipSerialization actual = XmlUtil.read(handler, SkipSerialization.class,
-				Files.readString(Paths.get(getClass().getClassLoader().getResource("skip-serialization.xml").toURI())));
+				new String(
+						Files.readAllBytes(
+								Paths.get(getClass().getClassLoader().getResource("skip-serialization.xml").toURI())),
+						StandardCharsets.UTF_8));
 		SkipSerialization expected = model;
 
 		Assertions.assertEquals(expected.getId(), actual.getId());

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/StringSerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/StringSerializationTest.java
@@ -1,5 +1,6 @@
 package com.ijioio.aes.sandbox.test;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -22,7 +23,6 @@ public class StringSerializationTest {
 					@EntityProperty(name = "valueString", type = @Type(name = Type.STRING)) //
 			} //
 	)
-
 	public static interface StringSerializationPrototype {
 
 		public static final String NAME = "com.ijioio.test.model.StringSerialization";
@@ -45,8 +45,10 @@ public class StringSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		String actual = XmlUtil.write(handler, model);
-		String expected = Files
-				.readString(Paths.get(getClass().getClassLoader().getResource("string-serialization.xml").toURI()));
+		String expected = new String(
+				Files.readAllBytes(
+						Paths.get(getClass().getClassLoader().getResource("string-serialization.xml").toURI())),
+				StandardCharsets.UTF_8);
 
 		Assertions.assertEquals(expected, actual);
 	}
@@ -56,8 +58,11 @@ public class StringSerializationTest {
 
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
-		StringSerialization actual = XmlUtil.read(handler, StringSerialization.class, Files
-				.readString(Paths.get(getClass().getClassLoader().getResource("string-serialization.xml").toURI())));
+		StringSerialization actual = XmlUtil.read(handler, StringSerialization.class,
+				new String(
+						Files.readAllBytes(
+								Paths.get(getClass().getClassLoader().getResource("string-serialization.xml").toURI())),
+						StandardCharsets.UTF_8));
 		StringSerialization expected = model;
 
 		Assertions.assertEquals(expected.getId(), actual.getId());

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/StringSerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/StringSerializationTest.java
@@ -2,6 +2,7 @@ package com.ijioio.aes.sandbox.test;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Assertions;
@@ -28,10 +29,14 @@ public class StringSerializationTest {
 		public static final String NAME = "com.ijioio.test.model.StringSerialization";
 	}
 
+	private Path path;
+
 	private StringSerialization model;
 
 	@BeforeEach
-	public void before() {
+	public void before() throws Exception {
+
+		path = Paths.get(getClass().getClassLoader().getResource("string-serialization.xml").toURI());
 
 		model = new StringSerialization();
 
@@ -45,10 +50,7 @@ public class StringSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		String actual = XmlUtil.write(handler, model);
-		String expected = new String(
-				Files.readAllBytes(
-						Paths.get(getClass().getClassLoader().getResource("string-serialization.xml").toURI())),
-				StandardCharsets.UTF_8);
+		String expected = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
 
 		Assertions.assertEquals(expected, actual);
 	}
@@ -59,10 +61,7 @@ public class StringSerializationTest {
 		XmlSerializationHandler handler = new XmlSerializationHandler();
 
 		StringSerialization actual = XmlUtil.read(handler, StringSerialization.class,
-				new String(
-						Files.readAllBytes(
-								Paths.get(getClass().getClassLoader().getResource("string-serialization.xml").toURI())),
-						StandardCharsets.UTF_8));
+				new String(Files.readAllBytes(path), StandardCharsets.UTF_8));
 		StringSerialization expected = model;
 
 		Assertions.assertEquals(expected.getId(), actual.getId());


### PR DESCRIPTION
In serialziation tests were used some Java 11 API. We need to downgrade test to use at most Java 8 API.