### PR TITLE
Support of repeatable identity values

### DIFF
--- a/aes-core/src/main/java/com/ijioio/aes/core/serialization/xml/XmlSerializationContext.java
+++ b/aes-core/src/main/java/com/ijioio/aes/core/serialization/xml/XmlSerializationContext.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 
+import com.ijioio.aes.core.Identity;
 import com.ijioio.aes.core.serialization.SerializationContext;
 
 public class XmlSerializationContext implements SerializationContext {
@@ -24,6 +25,8 @@ public class XmlSerializationContext implements SerializationContext {
 
 	private final Map<String, String> attributes = new HashMap<>();
 
+	private final Map<String, Identity> identities = new HashMap<>();
+
 	private XmlSerializationContext(XMLStreamWriter writer, XMLStreamReader reader) {
 
 		this.writer = writer;
@@ -40,5 +43,9 @@ public class XmlSerializationContext implements SerializationContext {
 
 	public Map<String, String> getAttributes() {
 		return attributes;
+	}
+
+	public Map<String, Identity> getIdentities() {
+		return identities;
 	}
 }

--- a/aes-core/src/main/java/com/ijioio/aes/core/serialization/xml/XmlSerializationHandler.java
+++ b/aes-core/src/main/java/com/ijioio/aes/core/serialization/xml/XmlSerializationHandler.java
@@ -52,7 +52,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				writer.writeCharacters(String.valueOf(value.booleanValue()));
 				writer.writeEndElement();
 
@@ -97,7 +97,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				writer.writeCharacters(String.valueOf(value.charValue()));
 				writer.writeEndElement();
 
@@ -143,7 +143,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				writer.writeCharacters(String.valueOf(value.byteValue()));
 				writer.writeEndElement();
 
@@ -188,7 +188,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				writer.writeCharacters(String.valueOf(value.intValue()));
 				writer.writeEndElement();
 
@@ -233,7 +233,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				writer.writeCharacters(String.valueOf(value.shortValue()));
 				writer.writeEndElement();
 
@@ -278,7 +278,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				writer.writeCharacters(String.valueOf(value.longValue()));
 				writer.writeEndElement();
 
@@ -323,7 +323,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				writer.writeCharacters(String.valueOf(value.floatValue()));
 				writer.writeEndElement();
 
@@ -368,7 +368,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				writer.writeCharacters(String.valueOf(value.doubleValue()));
 				writer.writeEndElement();
 
@@ -413,7 +413,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 
 				if (!TextUtil.isEmpty(value)) {
 					writer.writeCharacters(value);
@@ -462,7 +462,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				writer.writeCharacters(DateTimeFormatter.ISO_INSTANT.format(value));
 				writer.writeEndElement();
 
@@ -507,7 +507,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				writer.writeCharacters(DateTimeFormatter.ISO_LOCAL_DATE.format(value));
 				writer.writeEndElement();
 
@@ -552,7 +552,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				writer.writeCharacters(DateTimeFormatter.ISO_LOCAL_TIME.format(value));
 				writer.writeEndElement();
 
@@ -597,7 +597,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				writer.writeCharacters(DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(value));
 				writer.writeEndElement();
 
@@ -643,7 +643,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				writer.writeCharacters(value.name());
 				writer.writeEndElement();
 
@@ -691,7 +691,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 
 				for (Object value : values) {
 					handler.write(context, "item", value);
@@ -763,7 +763,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 
 				for (Entry<Object, Object> entry : ((Map<Object, Object>) values).entrySet()) {
 
@@ -848,7 +848,7 @@ public class XmlSerializationHandler implements SerializationHandler {
 			try {
 
 				writer.writeStartElement(name);
-				writeAttributes(writer, context.getAttributes());
+				handler.writeAttributes(writer, context.getAttributes());
 				value.write(context, handler);
 				writer.writeEndElement();
 
@@ -945,10 +945,16 @@ public class XmlSerializationHandler implements SerializationHandler {
 		return type;
 	}
 
-	public void writeAttributes(XMLStreamWriter writer, Map<String, String> attributes) throws XMLStreamException {
+	public void writeAttributes(XMLStreamWriter writer, Map<String, String> attributes) throws SerializationException {
 
-		for (Entry<String, String> entry : attributes.entrySet()) {
-			writer.writeAttribute(entry.getKey(), entry.getValue() != null ? entry.getValue() : "");
+		try {
+
+			for (Entry<String, String> entry : attributes.entrySet()) {
+				writer.writeAttribute(entry.getKey(), entry.getValue() != null ? entry.getValue() : "");
+			}
+
+		} catch (XMLStreamException e) {
+			throw new SerializationException(e);
 		}
 	}
 

--- a/aes-core/src/main/java/com/ijioio/aes/core/serialization/xml/XmlSerializationValueHandler.java
+++ b/aes-core/src/main/java/com/ijioio/aes/core/serialization/xml/XmlSerializationValueHandler.java
@@ -1,27 +1,14 @@
 package com.ijioio.aes.core.serialization.xml;
 
-import java.util.Map;
-import java.util.Map.Entry;
-
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-
 import com.ijioio.aes.core.serialization.SerializationException;
 
-public abstract class XmlSerializationValueHandler<T> {
+public interface XmlSerializationValueHandler<T> {
 
-	public abstract Class<T> getType();
+	public Class<T> getType();
 
-	public abstract void write(XmlSerializationContext context, XmlSerializationHandler handler, String name, T value)
+	public void write(XmlSerializationContext context, XmlSerializationHandler handler, String name, T value)
 			throws SerializationException;
 
-	public abstract T read(XmlSerializationContext context, XmlSerializationHandler handler, Class<T> type, T value)
+	public T read(XmlSerializationContext context, XmlSerializationHandler handler, Class<T> type, T value)
 			throws SerializationException;
-
-	protected void writeAttributes(XMLStreamWriter writer, Map<String, String> attributes) throws XMLStreamException {
-
-		for (Entry<String, String> entry : attributes.entrySet()) {
-			writer.writeAttribute(entry.getKey(), entry.getValue() != null ? entry.getValue() : "");
-		}
-	}
 }

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/CollectionSerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/CollectionSerializationTest.java
@@ -8,6 +8,7 @@ import java.time.Month;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -49,9 +50,9 @@ public class CollectionSerializationTest {
 
 		path = Paths.get(getClass().getClassLoader().getResource("collection-serialization.xml").toURI());
 
-		ArrayList<String> stringList = new ArrayList<>(Arrays.asList("value1", "value2", "value3"));
-		ArrayList<Month> enumList = new ArrayList<>(Arrays.asList(Month.JANUARY, Month.FEBRUARY, Month.MARCH));
-		ArrayList<Object> objectList = new ArrayList<>(Arrays.asList("value", Month.JANUARY));
+		List<String> stringList = new ArrayList<>(Arrays.asList("value1", "value2", "value3"));
+		List<Month> enumList = new ArrayList<>(Arrays.asList(Month.JANUARY, Month.FEBRUARY, Month.MARCH));
+		List<Object> objectList = new ArrayList<>(Arrays.asList("value", Month.JANUARY));
 
 		Set<String> stringSet = new LinkedHashSet<>(Arrays.asList("value1", "value2", "value3"));
 		Set<Month> enumSet = new LinkedHashSet<>(Arrays.asList(Month.JANUARY, Month.FEBRUARY, Month.MARCH));

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/IdentitySerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/IdentitySerializationTest.java
@@ -1,0 +1,225 @@
+package com.ijioio.aes.sandbox.test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ijioio.aes.annotation.Entity;
+import com.ijioio.aes.annotation.EntityProperty;
+import com.ijioio.aes.annotation.Type;
+import com.ijioio.aes.core.serialization.xml.XmlSerializationHandler;
+import com.ijioio.aes.core.serialization.xml.XmlUtil;
+import com.ijioio.test.model.IdentityBarSerialization;
+import com.ijioio.test.model.IdentityFooSerialization;
+import com.ijioio.test.model.IdentitySerialization;
+
+public class IdentitySerializationTest {
+
+	@Entity( //
+			name = IdentitySerializationPrototype.NAME, //
+			properties = { //
+					@EntityProperty(name = "valueIdentityFoo", type = @Type(name = IdentityFooSerializationPrototype.NAME)), //
+					@EntityProperty(name = "valueIdentityBar", type = @Type(name = IdentityBarSerializationPrototype.NAME)), //
+					@EntityProperty(name = "valueIdentityFooList", type = @Type(name = Type.LIST), parameters = @Type(name = IdentityFooSerializationPrototype.NAME)), //
+					@EntityProperty(name = "valueIdentityBarList", type = @Type(name = Type.LIST), parameters = @Type(name = IdentityBarSerializationPrototype.NAME)), //
+					@EntityProperty(name = "valueIdentityMixList", type = @Type(name = Type.LIST), parameters = @Type(name = "java.lang.Object")), //
+					@EntityProperty(name = "valueIdentityFooSet", type = @Type(name = Type.SET), parameters = @Type(name = IdentityFooSerializationPrototype.NAME)), //
+					@EntityProperty(name = "valueIdentityBarSet", type = @Type(name = Type.SET), parameters = @Type(name = IdentityBarSerializationPrototype.NAME)), //
+					@EntityProperty(name = "valueIdentityMixSet", type = @Type(name = Type.SET), parameters = @Type(name = "java.lang.Object")), //
+					@EntityProperty(name = "valueIdentityFooMap", type = @Type(name = Type.MAP), parameters = {
+							@Type(name = Type.STRING), @Type(name = IdentityFooSerializationPrototype.NAME) }), //
+					@EntityProperty(name = "valueIdentityBarMap", type = @Type(name = Type.MAP), parameters = {
+							@Type(name = Type.STRING), @Type(name = IdentityBarSerializationPrototype.NAME) }), //
+					@EntityProperty(name = "valueIdentityMixMap", type = @Type(name = Type.MAP), parameters = {
+							@Type(name = Type.STRING), @Type(name = "java.lang.Object") }), //
+			} //
+	)
+	public static interface IdentitySerializationPrototype {
+
+		public static final String NAME = "com.ijioio.test.model.IdentitySerialization";
+	}
+
+	@Entity( //
+			name = IdentityFooSerializationPrototype.NAME //
+	)
+	public static interface IdentityFooSerializationPrototype {
+
+		public static final String NAME = "com.ijioio.test.model.IdentityFooSerialization";
+	}
+
+	@Entity( //
+			name = IdentityBarSerializationPrototype.NAME //
+	)
+	public static interface IdentityBarSerializationPrototype {
+
+		public static final String NAME = "com.ijioio.test.model.IdentityBarSerialization";
+	}
+
+	private Path path;
+
+	private IdentitySerialization model;
+
+	private IdentityFooSerialization fooModel;
+
+	private IdentityBarSerialization barModel;
+
+	@BeforeEach
+	public void before() throws Exception {
+
+		path = Paths.get(getClass().getClassLoader().getResource("identity-serialization.xml").toURI());
+
+		fooModel = new IdentityFooSerialization();
+
+		fooModel.setId("identity-foo-serialization");
+
+		barModel = new IdentityBarSerialization();
+
+		barModel.setId("identity-bar-serialization");
+
+		List<IdentityFooSerialization> identityFooList = new ArrayList<>(Arrays.asList(fooModel, fooModel));
+		List<IdentityBarSerialization> identityBarList = new ArrayList<>(Arrays.asList(barModel, barModel));
+		List<Object> identityMixList = new ArrayList<>(Arrays.asList(fooModel, barModel));
+
+		Set<IdentityFooSerialization> identityFooSet = new LinkedHashSet<>(Arrays.asList(fooModel));
+		Set<IdentityBarSerialization> identityBarSet = new LinkedHashSet<>(Arrays.asList(barModel));
+		Set<Object> identityMixSet = new LinkedHashSet<>(Arrays.asList(fooModel, barModel));
+
+		Map<String, IdentityFooSerialization> identityFooMap = new LinkedHashMap<>();
+
+		identityFooMap.put("key1", fooModel);
+		identityFooMap.put("key2", fooModel);
+
+		Map<String, IdentityBarSerialization> identityBarMap = new LinkedHashMap<>();
+
+		identityBarMap.put("key1", barModel);
+		identityBarMap.put("key2", barModel);
+
+		Map<String, Object> identityMixMap = new LinkedHashMap<>();
+
+		identityMixMap.put("key1", fooModel);
+		identityMixMap.put("key2", barModel);
+
+		model = new IdentitySerialization();
+
+		model.setId("identity-serialization");
+		model.setValueIdentityFoo(fooModel);
+		model.setValueIdentityBar(barModel);
+		model.setValueIdentityFooList(identityFooList);
+		model.setValueIdentityBarList(identityBarList);
+		model.setValueIdentityMixList(identityMixList);
+		model.setValueIdentityFooSet(identityFooSet);
+		model.setValueIdentityBarSet(identityBarSet);
+		model.setValueIdentityMixSet(identityMixSet);
+		model.setValueIdentityFooMap(identityFooMap);
+		model.setValueIdentityBarMap(identityBarMap);
+		model.setValueIdentityMixMap(identityMixMap);
+	}
+
+	@Test
+	public void testWrite() throws Exception {
+
+		XmlSerializationHandler handler = new XmlSerializationHandler();
+
+		String actual = XmlUtil.write(handler, model);
+		String expected = Files.lines(path, StandardCharsets.UTF_8).collect(Collectors.joining("\n"));
+
+		Assertions.assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testRead() throws Exception {
+
+		XmlSerializationHandler handler = new XmlSerializationHandler();
+
+		IdentitySerialization actual = XmlUtil.read(handler, IdentitySerialization.class,
+				Files.lines(path, StandardCharsets.UTF_8).collect(Collectors.joining("\n")));
+		IdentitySerialization expected = model;
+
+		Assertions.assertEquals(expected.getId(), actual.getId());
+		Assertions.assertEquals(expected.getValueIdentityFoo(), actual.getValueIdentityFoo());
+		Assertions.assertEquals(expected.getValueIdentityBar(), actual.getValueIdentityBar());
+		Assertions.assertEquals(expected.getValueIdentityFooList(), actual.getValueIdentityFooList());
+		Assertions.assertEquals(expected.getValueIdentityBarList(), actual.getValueIdentityBarList());
+		Assertions.assertEquals(expected.getValueIdentityFooList(), actual.getValueIdentityFooList());
+		Assertions.assertEquals(expected.getValueIdentityMixList(), actual.getValueIdentityMixList());
+		Assertions.assertEquals(expected.getValueIdentityBarSet(), actual.getValueIdentityBarSet());
+		Assertions.assertEquals(expected.getValueIdentityFooSet(), actual.getValueIdentityFooSet());
+		Assertions.assertEquals(expected.getValueIdentityMixSet(), actual.getValueIdentityMixSet());
+		Assertions.assertEquals(expected.getValueIdentityBarMap(), actual.getValueIdentityBarMap());
+		Assertions.assertEquals(expected.getValueIdentityFooMap(), actual.getValueIdentityFooMap());
+		Assertions.assertEquals(expected.getValueIdentityMixMap(), actual.getValueIdentityMixMap());
+
+		//////////////////////////////////////////////////////////////////
+		// Check all lists on object raw equal
+		//////////////////////////////////////////////////////////////////
+
+		Iterator<IdentityFooSerialization> valueIdentityFooListIterator = actual.getValueIdentityFooList().iterator();
+
+		Assertions.assertTrue(valueIdentityFooListIterator.next() == actual.getValueIdentityFoo());
+		Assertions.assertTrue(valueIdentityFooListIterator.next() == actual.getValueIdentityFoo());
+
+		Iterator<IdentityBarSerialization> valueIdentityBarListIterator = actual.getValueIdentityBarList().iterator();
+
+		Assertions.assertTrue(valueIdentityBarListIterator.next() == actual.getValueIdentityBar());
+		Assertions.assertTrue(valueIdentityBarListIterator.next() == actual.getValueIdentityBar());
+
+		Iterator<Object> valueIdentityMixListIterator = actual.getValueIdentityMixList().iterator();
+
+		Assertions.assertTrue(valueIdentityMixListIterator.next() == actual.getValueIdentityFoo());
+		Assertions.assertTrue(valueIdentityMixListIterator.next() == actual.getValueIdentityBar());
+
+		//////////////////////////////////////////////////////////////////
+		// Check all sets on object raw equal
+		//////////////////////////////////////////////////////////////////
+
+		Iterator<IdentityFooSerialization> valueIdentityFooSetIterator = actual.getValueIdentityFooSet().iterator();
+
+		Assertions.assertTrue(valueIdentityFooSetIterator.next() == actual.getValueIdentityFoo());
+
+		Iterator<IdentityBarSerialization> valueIdentityBarSetIterator = actual.getValueIdentityBarSet().iterator();
+
+		Assertions.assertTrue(valueIdentityBarSetIterator.next() == actual.getValueIdentityBar());
+
+		Iterator<Object> valueIdentityMixSetIterator = actual.getValueIdentityMixSet().iterator();
+
+		Assertions.assertTrue(valueIdentityMixSetIterator.next() == actual.getValueIdentityFoo());
+		Assertions.assertTrue(valueIdentityMixSetIterator.next() == actual.getValueIdentityBar());
+
+		//////////////////////////////////////////////////////////////////
+		// Check all maps on object raw equal
+		//////////////////////////////////////////////////////////////////
+
+		Iterator<Entry<String, IdentityFooSerialization>> valueIdentityFooMapIterator = actual.getValueIdentityFooMap()
+				.entrySet().iterator();
+
+		Assertions.assertTrue(valueIdentityFooMapIterator.next().getValue() == actual.getValueIdentityFoo());
+		Assertions.assertTrue(valueIdentityFooMapIterator.next().getValue() == actual.getValueIdentityFoo());
+
+		Iterator<Entry<String, IdentityBarSerialization>> valueIdentityBarMapIterator = actual.getValueIdentityBarMap()
+				.entrySet().iterator();
+
+		Assertions.assertTrue(valueIdentityBarMapIterator.next().getValue() == actual.getValueIdentityBar());
+		Assertions.assertTrue(valueIdentityBarMapIterator.next().getValue() == actual.getValueIdentityBar());
+
+		Iterator<Entry<String, Object>> valueIdentityMixMapIterator = actual.getValueIdentityMixMap().entrySet()
+				.iterator();
+
+		Assertions.assertTrue(valueIdentityMixMapIterator.next().getValue() == actual.getValueIdentityFoo());
+		Assertions.assertTrue(valueIdentityMixMapIterator.next().getValue() == actual.getValueIdentityBar());
+	}
+}

--- a/aes-sandbox/src/test/resources/identity-serialization.xml
+++ b/aes-sandbox/src/test/resources/identity-serialization.xml
@@ -1,0 +1,61 @@
+<object class="com.ijioio.test.model.IdentitySerialization">
+    <id>identity-serialization</id>
+    <valueIdentityFoo class="com.ijioio.test.model.IdentityFooSerialization">
+        <id>identity-foo-serialization</id>
+    </valueIdentityFoo>
+    <valueIdentityBar class="com.ijioio.test.model.IdentityBarSerialization">
+        <id>identity-bar-serialization</id>
+    </valueIdentityBar>
+    <valueIdentityFooList class="java.util.ArrayList">
+        <item id="identity-foo-serialization" class="com.ijioio.test.model.IdentityFooSerialization"/>
+        <item id="identity-foo-serialization" class="com.ijioio.test.model.IdentityFooSerialization"/>
+    </valueIdentityFooList>
+    <valueIdentityBarList class="java.util.ArrayList">
+        <item id="identity-bar-serialization" class="com.ijioio.test.model.IdentityBarSerialization"/>
+        <item id="identity-bar-serialization" class="com.ijioio.test.model.IdentityBarSerialization"/>
+    </valueIdentityBarList>
+    <valueIdentityMixList class="java.util.ArrayList">
+        <item id="identity-foo-serialization" class="com.ijioio.test.model.IdentityFooSerialization"/>
+        <item id="identity-bar-serialization" class="com.ijioio.test.model.IdentityBarSerialization"/>
+    </valueIdentityMixList>
+    <valueIdentityFooSet class="java.util.LinkedHashSet">
+        <item id="identity-foo-serialization" class="com.ijioio.test.model.IdentityFooSerialization"/>
+    </valueIdentityFooSet>
+    <valueIdentityBarSet class="java.util.LinkedHashSet">
+        <item id="identity-bar-serialization" class="com.ijioio.test.model.IdentityBarSerialization"/>
+    </valueIdentityBarSet>
+    <valueIdentityMixSet class="java.util.LinkedHashSet">
+        <item id="identity-foo-serialization" class="com.ijioio.test.model.IdentityFooSerialization"/>
+        <item id="identity-bar-serialization" class="com.ijioio.test.model.IdentityBarSerialization"/>
+    </valueIdentityMixSet>
+    <valueIdentityFooMap class="java.util.LinkedHashMap">
+        <entry>
+            <key class="java.lang.String">key1</key>
+            <value id="identity-foo-serialization" class="com.ijioio.test.model.IdentityFooSerialization"/>
+        </entry>
+        <entry>
+            <key class="java.lang.String">key2</key>
+            <value id="identity-foo-serialization" class="com.ijioio.test.model.IdentityFooSerialization"/>
+        </entry>
+    </valueIdentityFooMap>
+    <valueIdentityBarMap class="java.util.LinkedHashMap">
+        <entry>
+            <key class="java.lang.String">key1</key>
+            <value id="identity-bar-serialization" class="com.ijioio.test.model.IdentityBarSerialization"/>
+        </entry>
+        <entry>
+            <key class="java.lang.String">key2</key>
+            <value id="identity-bar-serialization" class="com.ijioio.test.model.IdentityBarSerialization"/>
+        </entry>
+    </valueIdentityBarMap>
+    <valueIdentityMixMap class="java.util.LinkedHashMap">
+        <entry>
+            <key class="java.lang.String">key1</key>
+            <value id="identity-foo-serialization" class="com.ijioio.test.model.IdentityFooSerialization"/>
+        </entry>
+        <entry>
+            <key class="java.lang.String">key2</key>
+            <value id="identity-bar-serialization" class="com.ijioio.test.model.IdentityBarSerialization"/>
+        </entry>
+    </valueIdentityMixMap>
+</object>


### PR DESCRIPTION
In case of writing property of type `Identity` multiple times, it should be serialized only once.

See #35 