### PR TITLE
Refactoring of XSerializable

### DIFF
--- a/aes-core/src/main/java/com/ijioio/aes/core/BaseEntity.java
+++ b/aes-core/src/main/java/com/ijioio/aes/core/BaseEntity.java
@@ -4,6 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.ijioio.aes.core.serialization.SerializationContext;
+import com.ijioio.aes.core.serialization.SerializationException;
 import com.ijioio.aes.core.serialization.SerializationHandler;
 import com.ijioio.aes.core.serialization.SerializationReader;
 import com.ijioio.aes.core.serialization.SerializationWriter;
@@ -14,6 +15,15 @@ import com.ijioio.aes.core.serialization.SerializationWriter;
 public abstract class BaseEntity extends BaseIdentity implements Entity {
 
 	@Override
+	public void write(SerializationContext context, SerializationHandler handler) throws SerializationException {
+		handler.write(context, getWriters(context, handler));
+	}
+
+	@Override
+	public void read(SerializationContext context, SerializationHandler handler) throws SerializationException {
+		handler.read(context, getReaders(context, handler));
+	}
+
 	public Map<String, SerializationWriter> getWriters(SerializationContext context, SerializationHandler handler) {
 
 		Map<String, SerializationWriter> writers = new LinkedHashMap<>();
@@ -23,7 +33,6 @@ public abstract class BaseEntity extends BaseIdentity implements Entity {
 		return writers;
 	}
 
-	@Override
 	public Map<String, SerializationReader> getReaders(SerializationContext context, SerializationHandler handler) {
 
 		Map<String, SerializationReader> readers = new LinkedHashMap<>();

--- a/aes-core/src/main/java/com/ijioio/aes/core/XSerializable.java
+++ b/aes-core/src/main/java/com/ijioio/aes/core/XSerializable.java
@@ -1,25 +1,12 @@
 package com.ijioio.aes.core;
 
-import java.util.Map;
-
 import com.ijioio.aes.core.serialization.SerializationContext;
 import com.ijioio.aes.core.serialization.SerializationException;
 import com.ijioio.aes.core.serialization.SerializationHandler;
-import com.ijioio.aes.core.serialization.SerializationReader;
-import com.ijioio.aes.core.serialization.SerializationWriter;
 
 public interface XSerializable {
 
-	public Map<String, SerializationWriter> getWriters(SerializationContext context, SerializationHandler handler);
+	public void write(SerializationContext context, SerializationHandler handler) throws SerializationException;
 
-	public Map<String, SerializationReader> getReaders(SerializationContext context, SerializationHandler handler);
-
-	public default void write(SerializationContext context, SerializationHandler handler)
-			throws SerializationException {
-		handler.write(context, getWriters(context, handler));
-	}
-
-	public default void read(SerializationContext context, SerializationHandler handler) throws SerializationException {
-		handler.read(context, getReaders(context, handler));
-	}
+	public void read(SerializationContext context, SerializationHandler handler) throws SerializationException;
 }

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/PrioritySerializationTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/PrioritySerializationTest.java
@@ -5,10 +5,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.xml.stream.XMLStreamConstants;
@@ -27,8 +25,6 @@ import com.ijioio.aes.core.XSerializable;
 import com.ijioio.aes.core.serialization.SerializationContext;
 import com.ijioio.aes.core.serialization.SerializationException;
 import com.ijioio.aes.core.serialization.SerializationHandler;
-import com.ijioio.aes.core.serialization.SerializationReader;
-import com.ijioio.aes.core.serialization.SerializationWriter;
 import com.ijioio.aes.core.serialization.xml.XmlSerializationContext;
 import com.ijioio.aes.core.serialization.xml.XmlSerializationHandler;
 import com.ijioio.aes.core.serialization.xml.XmlUtil;
@@ -39,16 +35,6 @@ public class PrioritySerializationTest {
 	public static class XSerializableList extends ArrayList<String> implements XSerializable {
 
 		private static final long serialVersionUID = 829086422127798594L;
-
-		@Override
-		public Map<String, SerializationWriter> getWriters(SerializationContext context, SerializationHandler handler) {
-			return Collections.emptyMap();
-		}
-
-		@Override
-		public Map<String, SerializationReader> getReaders(SerializationContext context, SerializationHandler handler) {
-			return Collections.emptyMap();
-		}
 
 		@Override
 		public void write(SerializationContext context, SerializationHandler handler) throws SerializationException {
@@ -96,16 +82,6 @@ public class PrioritySerializationTest {
 		private static final long serialVersionUID = 4675527390057694654L;
 
 		@Override
-		public Map<String, SerializationWriter> getWriters(SerializationContext context, SerializationHandler handler) {
-			return Collections.emptyMap();
-		}
-
-		@Override
-		public Map<String, SerializationReader> getReaders(SerializationContext context, SerializationHandler handler) {
-			return Collections.emptyMap();
-		}
-
-		@Override
 		public void write(SerializationContext context, SerializationHandler handler) throws SerializationException {
 
 			XMLStreamWriter writer = ((XmlSerializationContext) context).getWriter();
@@ -149,16 +125,6 @@ public class PrioritySerializationTest {
 	public static class XSerializableMap extends HashMap<String, String> implements XSerializable {
 
 		private static final long serialVersionUID = 1104595344886510054L;
-
-		@Override
-		public Map<String, SerializationWriter> getWriters(SerializationContext context, SerializationHandler handler) {
-			return Collections.emptyMap();
-		}
-
-		@Override
-		public Map<String, SerializationReader> getReaders(SerializationContext context, SerializationHandler handler) {
-			return Collections.emptyMap();
-		}
 
 		@Override
 		public void write(SerializationContext context, SerializationHandler handler) throws SerializationException {


### PR DESCRIPTION
To make structure more clear, it is needed to refactor `XSerializable` interface to leave only non default write/read methods, and move imlementation to the `BaseEntity` class.

See #46