### PR TITLE
Entity index interface 

### DIFF
--- a/aes-core/src/main/java/com/ijioio/aes/core/EntityIndex.java
+++ b/aes-core/src/main/java/com/ijioio/aes/core/EntityIndex.java
@@ -1,0 +1,10 @@
+package com.ijioio.aes.core;
+
+/**
+ * Interface defining index of the entity. Entity index contains some entity
+ * properties.
+ */
+public interface EntityIndex<E extends BaseEntity> extends Identity {
+
+	public EntityReference<E> getSource();
+}


### PR DESCRIPTION
Before we can generate entity index implementations we need to create base interface for the entity index.

See #49 