### PR TITLE
Property final attribute validation checks

### DIFF
--- a/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/EntityPropertyMetadata.java
+++ b/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/EntityPropertyMetadata.java
@@ -18,6 +18,7 @@ import com.ijioio.aes.annotation.processor.exception.EntityPropertyIllegalStateE
 import com.ijioio.aes.annotation.processor.exception.ProcessorException;
 import com.ijioio.aes.annotation.processor.util.ProcessorUtil;
 import com.ijioio.aes.annotation.processor.util.TextUtil;
+import com.ijioio.aes.annotation.processor.util.TypeUtil;
 
 public class EntityPropertyMetadata {
 
@@ -109,6 +110,12 @@ public class EntityPropertyMetadata {
 
 		if (type == null) {
 			throw new EntityPropertyIllegalStateException(String.format("Type of the entity property is not defined"),
+					MessageContext.of(context.getElement(), context.getAnnotationMirror(), null));
+		}
+
+		if (attributes.contains(Attribute.FINAL) && TypeUtil.isImmutable(type.getName())) {
+			throw new EntityPropertyIllegalStateException(
+					String.format("Final attribute is not allowed for the immutable types"),
 					MessageContext.of(context.getElement(), context.getAnnotationMirror(), null));
 		}
 	}


### PR DESCRIPTION
It should be validated against using of final attribute for the property types (at least for the predefined types) that are immutable.

See #54 