### PR TITLE
Use column names on search

### DIFF
--- a/aes-core/src/main/java/com/ijioio/aes/core/persistence/jdbc/JdbcPersistenceHandler.java
+++ b/aes-core/src/main/java/com/ijioio/aes/core/persistence/jdbc/JdbcPersistenceHandler.java
@@ -669,7 +669,8 @@ public class JdbcPersistenceHandler implements PersistenceHandler<JdbcPersistenc
 
 			Property<String> nameProperty = Property.of(property.getName(), TypeReference.of(String.class));
 
-			JdbcPersistenceValueHandler<String> nameHandler = handler.getValueHandler(String.class);
+			JdbcPersistenceValueHandler<String> nameHandler = handler
+					.getValueHandler(nameProperty.getType().getRawType());
 
 			return nameHandler.getColumns(context, handler, nameProperty, search);
 		};
@@ -680,7 +681,8 @@ public class JdbcPersistenceHandler implements PersistenceHandler<JdbcPersistenc
 
 			Property<String> nameProperty = Property.of(property.getName(), TypeReference.of(String.class));
 
-			JdbcPersistenceValueHandler<String> nameHandler = handler.getValueHandler(String.class);
+			JdbcPersistenceValueHandler<String> nameHandler = handler
+					.getValueHandler(nameProperty.getType().getRawType());
 
 			nameHandler.write(context, handler, nameProperty, value != null ? value.getName() : null, search);
 		}
@@ -693,7 +695,8 @@ public class JdbcPersistenceHandler implements PersistenceHandler<JdbcPersistenc
 			Property<List<String>> nameProperty = Property.of(property.getName(), new TypeReference<List<String>>() {
 			});
 
-			JdbcPersistenceValueHandler<String> nameHandler = handler.getValueHandler(String.class);
+			JdbcPersistenceValueHandler<List<String>> nameHandler = handler
+					.getValueHandler(nameProperty.getType().getRawType());
 
 			List<String> nameValues = new ArrayList<>();
 
@@ -701,7 +704,7 @@ public class JdbcPersistenceHandler implements PersistenceHandler<JdbcPersistenc
 				nameValues.add(value != null ? value.getName() : null);
 			}
 
-			nameHandler.writeCollection(context, handler, nameProperty, nameValues, search);
+			nameHandler.write(context, handler, nameProperty, nameValues, search);
 		};
 
 		@Override
@@ -710,7 +713,8 @@ public class JdbcPersistenceHandler implements PersistenceHandler<JdbcPersistenc
 
 			Property<String> nameProperty = Property.of(property.getName(), TypeReference.of(String.class));
 
-			JdbcPersistenceValueHandler<String> nameHandler = handler.getValueHandler(String.class);
+			JdbcPersistenceValueHandler<String> nameHandler = handler
+					.getValueHandler(nameProperty.getType().getRawType());
 
 			try {
 				return Class.forName(nameHandler.read(context, handler, nameProperty, null));
@@ -726,9 +730,10 @@ public class JdbcPersistenceHandler implements PersistenceHandler<JdbcPersistenc
 			Property<List<String>> nameProperty = Property.of(property.getName(), new TypeReference<List<String>>() {
 			});
 
-			JdbcPersistenceValueHandler<String> nameHandler = handler.getValueHandler(String.class);
+			JdbcPersistenceValueHandler<List<String>> nameHandler = handler
+					.getValueHandler(nameProperty.getType().getRawType());
 
-			Collection<String> nameValues = nameHandler.readCollection(context, handler, nameProperty, null);
+			Collection<String> nameValues = nameHandler.read(context, handler, nameProperty, null);
 
 			Collection<Class> collection = List.class.isAssignableFrom(property.getType().getRawType())
 					? new ArrayList<>()
@@ -806,8 +811,9 @@ public class JdbcPersistenceHandler implements PersistenceHandler<JdbcPersistenc
 			Property<Class> typeProperty = Property.of(String.format("%sType", property.getName()),
 					TypeReference.of(Class.class));
 
-			JdbcPersistenceValueHandler<String> idHandler = handler.getValueHandler(String.class);
-			JdbcPersistenceValueHandler<Class> typeHandler = handler.getValueHandler(Class.class);
+			JdbcPersistenceValueHandler<String> idHandler = handler.getValueHandler(idProperty.getType().getRawType());
+			JdbcPersistenceValueHandler<Class> typeHandler = handler
+					.getValueHandler(typeProperty.getType().getRawType());
 
 			return Stream
 					.of(idHandler.getColumns(context, handler, idProperty, search),
@@ -824,8 +830,9 @@ public class JdbcPersistenceHandler implements PersistenceHandler<JdbcPersistenc
 			Property<Class> typeProperty = Property.of(String.format("%sType", property.getName()),
 					TypeReference.of(Class.class));
 
-			JdbcPersistenceValueHandler<String> idHandler = handler.getValueHandler(String.class);
-			JdbcPersistenceValueHandler<Class> typeHandler = handler.getValueHandler(Class.class);
+			JdbcPersistenceValueHandler<String> idHandler = handler.getValueHandler(idProperty.getType().getRawType());
+			JdbcPersistenceValueHandler<Class> typeHandler = handler
+					.getValueHandler(typeProperty.getType().getRawType());
 
 			idHandler.write(context, handler, idProperty, value != null ? value.getId() : null, search);
 			typeHandler.write(context, handler, typeProperty, value != null ? value.getType() : null, search);
@@ -843,8 +850,10 @@ public class JdbcPersistenceHandler implements PersistenceHandler<JdbcPersistenc
 					new TypeReference<List<Class>>() {
 					});
 
-			JdbcPersistenceValueHandler<String> idHandler = handler.getValueHandler(String.class);
-			JdbcPersistenceValueHandler<Class> typeHandler = handler.getValueHandler(Class.class);
+			JdbcPersistenceValueHandler<List<String>> idHandler = handler
+					.getValueHandler(idProperty.getType().getRawType());
+			JdbcPersistenceValueHandler<List<Class>> typeHandler = handler
+					.getValueHandler(typeProperty.getType().getRawType());
 
 			List<String> idValues = new ArrayList<>();
 			List<Class> typeValues = new ArrayList<>();
@@ -855,8 +864,8 @@ public class JdbcPersistenceHandler implements PersistenceHandler<JdbcPersistenc
 				typeValues.add(value != null ? value.getType() : null);
 			}
 
-			idHandler.writeCollection(context, handler, idProperty, idValues, search);
-			typeHandler.writeCollection(context, handler, typeProperty, typeValues, search);
+			idHandler.write(context, handler, idProperty, idValues, search);
+			typeHandler.write(context, handler, typeProperty, typeValues, search);
 		}
 
 		@SuppressWarnings("unchecked")
@@ -869,8 +878,9 @@ public class JdbcPersistenceHandler implements PersistenceHandler<JdbcPersistenc
 			Property<Class> typeProperty = Property.of(String.format("%sType", property.getName()),
 					TypeReference.of(Class.class));
 
-			JdbcPersistenceValueHandler<String> idHandler = handler.getValueHandler(String.class);
-			JdbcPersistenceValueHandler<Class> typeHandler = handler.getValueHandler(Class.class);
+			JdbcPersistenceValueHandler<String> idHandler = handler.getValueHandler(idProperty.getType().getRawType());
+			JdbcPersistenceValueHandler<Class> typeHandler = handler
+					.getValueHandler(typeProperty.getType().getRawType());
 
 			String idValue = idHandler.read(context, handler, idProperty, null);
 			Class typeValue = typeHandler.read(context, handler, typeProperty, null);
@@ -891,11 +901,13 @@ public class JdbcPersistenceHandler implements PersistenceHandler<JdbcPersistenc
 					new TypeReference<List<Class>>() {
 					});
 
-			JdbcPersistenceValueHandler<String> idHandler = handler.getValueHandler(String.class);
-			JdbcPersistenceValueHandler<Class> typeHandler = handler.getValueHandler(Class.class);
+			JdbcPersistenceValueHandler<List<String>> idHandler = handler
+					.getValueHandler(idProperty.getType().getRawType());
+			JdbcPersistenceValueHandler<List<Class>> typeHandler = handler
+					.getValueHandler(typeProperty.getType().getRawType());
 
-			Collection<String> idValues = idHandler.readCollection(context, handler, idProperty, null);
-			Collection<Class> typeValues = typeHandler.readCollection(context, handler, typeProperty, null);
+			Collection<String> idValues = idHandler.read(context, handler, idProperty, null);
+			Collection<Class> typeValues = typeHandler.read(context, handler, typeProperty, null);
 
 			if (idValues.size() != typeValues.size()) {
 				throw new PersistenceException(String

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/persistence/index/property/PropertyClassListCreatePersistenceTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/persistence/index/property/PropertyClassListCreatePersistenceTest.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -20,50 +21,50 @@ import com.ijioio.aes.core.EntityReference;
 import com.ijioio.aes.core.persistence.jdbc.JdbcPersistenceContext;
 import com.ijioio.aes.core.persistence.jdbc.JdbcPersistenceHandler;
 import com.ijioio.aes.sandbox.test.persistence.BasePersistenceTest;
-import com.ijioio.test.model.PropertyStringListCreatePersistence;
-import com.ijioio.test.model.PropertyStringListCreatePersistenceIndex;
+import com.ijioio.test.model.PropertyClassListCreatePersistence;
+import com.ijioio.test.model.PropertyClassListCreatePersistenceIndex;
 
-public class PropertyStringListCreatePersistenceTest extends BasePersistenceTest {
+public class PropertyClassListCreatePersistenceTest extends BasePersistenceTest {
 
 	@Entity( //
-			name = PropertyStringCreatePersistencePrototype.NAME, //
+			name = PropertyClassListCreatePersistencePrototype.NAME, //
 			properties = { //
-					@EntityProperty(name = "valueStringList", type = @Type(name = Type.LIST), parameters = @Type(name = Type.STRING)) //
+					@EntityProperty(name = "valueClassList", type = @Type(name = Type.LIST), parameters = @Type(name = Type.CLASS)) //
 			}, //
 			indexes = { //
 					@EntityIndex( //
-							name = PropertyStringCreatePersistencePrototype.INDEX_NAME, //
+							name = PropertyClassListCreatePersistencePrototype.INDEX_NAME, //
 							properties = { //
-									@EntityIndexProperty(name = "valueStringList", type = @Type(name = Type.LIST), parameters = @Type(name = Type.STRING)) //
+									@EntityIndexProperty(name = "valueClassList", type = @Type(name = Type.LIST), parameters = @Type(name = Type.CLASS)) //
 							} //
 					) //
 			} //
 	)
-	public static interface PropertyStringCreatePersistencePrototype {
+	public static interface PropertyClassListCreatePersistencePrototype {
 
-		public static final String NAME = "com.ijioio.test.model.PropertyStringListCreatePersistence";
+		public static final String NAME = "com.ijioio.test.model.PropertyClassListCreatePersistence";
 
-		public static final String INDEX_NAME = "com.ijioio.test.model.PropertyStringListCreatePersistenceIndex";
+		public static final String INDEX_NAME = "com.ijioio.test.model.PropertyClassListCreatePersistenceIndex";
 	}
 
 	private Path path;
 
-	private PropertyStringListCreatePersistenceIndex index;
+	private PropertyClassListCreatePersistenceIndex index;
 
 	@BeforeEach
 	public void before() throws Exception {
 
 		path = Paths.get(getClass().getClassLoader()
-				.getResource("persistence/index/property/property-string-list-create-persistence.sql").toURI());
+				.getResource("persistence/index/property/property-class-list-create-persistence.sql").toURI());
 
 		executeSql(connection, path);
 
-		index = new PropertyStringListCreatePersistenceIndex();
+		index = new PropertyClassListCreatePersistenceIndex();
 
-		index.setId("property-string-list-create-persistence-index");
-		index.setSource(EntityReference.of("property-string-list-create-persistence",
-				PropertyStringListCreatePersistence.class));
-		index.setValueStringList(Arrays.asList("value1", "value2", "value3"));
+		index.setId("property-class-list-create-persistence-index");
+		index.setSource(
+				EntityReference.of("property-class-list-create-persistence", PropertyClassListCreatePersistence.class));
+		index.setValueClassList(Arrays.asList(String.class, Number.class, Instant.class));
 	}
 
 	@Test
@@ -74,7 +75,7 @@ public class PropertyStringListCreatePersistenceTest extends BasePersistenceTest
 		handler.create(JdbcPersistenceContext.of(connection), index);
 
 		try (PreparedStatement statement = connection.prepareStatement(
-				String.format("select * from %s", PropertyStringListCreatePersistenceIndex.class.getSimpleName()))) {
+				String.format("select * from %s", PropertyClassListCreatePersistenceIndex.class.getSimpleName()))) {
 
 			try (ResultSet resultSet = statement.executeQuery()) {
 
@@ -83,8 +84,9 @@ public class PropertyStringListCreatePersistenceTest extends BasePersistenceTest
 				Assertions.assertEquals(index.getId(), resultSet.getString("id"));
 				Assertions.assertEquals(index.getSource().getId(), resultSet.getString("sourceId"));
 				Assertions.assertEquals(index.getSource().getType().getName(), resultSet.getString("sourceType"));
-				Assertions.assertEquals(index.getValueStringList(),
-						Arrays.asList((Object[]) resultSet.getArray("valueStringList").getArray()));
+				Assertions.assertEquals(
+						index.getValueClassList().stream().map(item -> item.getName()).collect(Collectors.toList()),
+						Arrays.asList((Object[]) resultSet.getArray("valueClassList").getArray()));
 
 				Assertions.assertTrue(resultSet.isLast());
 			}

--- a/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/persistence/index/property/PropertyEntityReferenceListCreatePersistenceTest.java
+++ b/aes-sandbox/src/test/java/com/ijioio/aes/sandbox/test/persistence/index/property/PropertyEntityReferenceListCreatePersistenceTest.java
@@ -94,13 +94,11 @@ public class PropertyEntityReferenceListCreatePersistenceTest extends BasePersis
 				Assertions.assertEquals(
 						index.getValueEntityReferenceList().stream().map(item -> item.getId())
 								.collect(Collectors.toList()),
-						Arrays.stream((Object[]) resultSet.getArray("valueEntityReferenceListId").getArray())
-								.map(item -> (String) item).collect(Collectors.toList()));
+						Arrays.asList((Object[]) resultSet.getArray("valueEntityReferenceListId").getArray()));
 				Assertions.assertEquals(
 						index.getValueEntityReferenceList().stream().map(item -> item.getType().getName())
 								.collect(Collectors.toList()),
-						Arrays.stream((Object[]) resultSet.getArray("valueEntityReferenceListType").getArray())
-								.map(item -> (String) item).collect(Collectors.toList()));
+						Arrays.asList((Object[]) resultSet.getArray("valueEntityReferenceListType").getArray()));
 
 				Assertions.assertTrue(resultSet.isLast());
 			}

--- a/aes-sandbox/src/test/resources/persistence/index/property/property-class-list-create-persistence.sql
+++ b/aes-sandbox/src/test/resources/persistence/index/property/property-class-list-create-persistence.sql
@@ -1,0 +1,7 @@
+drop table if exists PropertyClassListCreatePersistenceIndex;
+create table PropertyClassListCreatePersistenceIndex(
+	id varchar(256) primary key,
+	sourceId varchar(256) not null,
+	sourceType varchar(256) not null,
+	valueClassList varchar(512) array
+);


### PR DESCRIPTION
We should use explicit names for all the columns in a query during search.

See #87 