### PR TITLE
Extract type annotations

### DIFF
--- a/aes-annotation/src/main/java/com/ijioio/aes/annotation/Type.java
+++ b/aes-annotation/src/main/java/com/ijioio/aes/annotation/Type.java
@@ -52,4 +52,10 @@ public @interface Type {
 	public String type();
 
 	public Parameter[] parameters() default {};
+
+	public boolean list() default false;
+
+	public boolean set() default false;
+
+	public boolean reference() default false;
 }

--- a/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/EntityIndexPropertyMetadata.java
+++ b/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/EntityIndexPropertyMetadata.java
@@ -35,11 +35,11 @@ public class EntityIndexPropertyMetadata {
 
 	private String type;
 
+	private boolean reference;
+
 	private boolean list;
 
 	private boolean set;
-
-	private boolean reference;
 
 	private final Set<Attribute> attributes = new HashSet<>();
 
@@ -62,6 +62,10 @@ public class EntityIndexPropertyMetadata {
 
 				type = ProcessorUtil.stringVisitor.visit(value);
 
+			} else if (key.getSimpleName().contentEquals("reference")) {
+
+				reference = ProcessorUtil.booleanVisitor.visit(value).booleanValue();
+
 			} else if (key.getSimpleName().contentEquals("list")) {
 
 				list = ProcessorUtil.booleanVisitor.visit(value).booleanValue();
@@ -69,10 +73,6 @@ public class EntityIndexPropertyMetadata {
 			} else if (key.getSimpleName().contentEquals("set")) {
 
 				set = ProcessorUtil.booleanVisitor.visit(value).booleanValue();
-
-			} else if (key.getSimpleName().contentEquals("reference")) {
-
-				reference = ProcessorUtil.booleanVisitor.visit(value).booleanValue();
 
 			} else if (key.getSimpleName().contentEquals("attributes")) {
 
@@ -125,6 +125,10 @@ public class EntityIndexPropertyMetadata {
 		return type;
 	}
 
+	public boolean isReference() {
+		return reference;
+	}
+
 	public boolean isList() {
 		return list;
 	}
@@ -133,13 +137,9 @@ public class EntityIndexPropertyMetadata {
 		return set;
 	}
 
-	public boolean isReference() {
-		return reference;
-	}
-
 	@Override
 	public String toString() {
-		return "EntityIndexPropertyMetadata [name=" + name + ", type=" + type + ", list=" + list + ", set=" + set
-				+ ", reference=" + reference + ", attributes=" + attributes + "]";
+		return "EntityIndexPropertyMetadata [name=" + name + ", type=" + type + ", reference=" + reference + ", list="
+				+ list + ", set=" + set + ", attributes=" + attributes + "]";
 	}
 }

--- a/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/EntityProcessor.java
+++ b/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/EntityProcessor.java
@@ -123,31 +123,36 @@ public class EntityProcessor extends AbstractProcessor {
 
 		for (EntityPropertyMetadata property : properties) {
 
-			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes());
+			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes(), messager);
 
-			if (handler.isBoolean()) {
+			TypeName type = handler.getType();
+			TypeName implementationType = handler.getImplementationType();
+
+			if (type.equals(CodeGenTypeUtil.BOOLEAN_TYPE_NAME)) {
 				methods.add(MethodSpec.methodBuilder(String.format("is%s", TextUtil.capitalize(property.getName())))
-						.addModifiers(Modifier.PUBLIC).returns(handler.getParameterizedType())
-						.addStatement("return $L", property.getName()).build());
+						.addModifiers(Modifier.PUBLIC).returns(type).addStatement("return $L", property.getName())
+						.build());
 			} else {
 				methods.add(MethodSpec.methodBuilder(String.format("get%s", TextUtil.capitalize(property.getName())))
-						.addModifiers(Modifier.PUBLIC).returns(handler.getParameterizedType())
-						.addStatement("return $L", property.getName()).build());
+						.addModifiers(Modifier.PUBLIC).returns(type).addStatement("return $L", property.getName())
+						.build());
 			}
 
 			if (property.isFinal()) {
 
-				fields.add(FieldSpec.builder(handler.getParameterizedType(), property.getName())
-						.addModifiers(Modifier.PRIVATE, Modifier.FINAL)
-						.initializer("new $T()", handler.getParameterizedImplementationType()).build());
+				fields.add(FieldSpec.builder(type, property.getName()).addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+						.initializer((implementationType instanceof ParameterizedTypeName) ? "new $T<>()" : "new $T()",
+								(implementationType instanceof ParameterizedTypeName)
+										? ((ParameterizedTypeName) implementationType).rawType
+										: implementationType)
+						.build());
 
 			} else {
 
-				fields.add(FieldSpec.builder(handler.getParameterizedType(), property.getName())
-						.addModifiers(Modifier.PRIVATE).build());
+				fields.add(FieldSpec.builder(type, property.getName()).addModifiers(Modifier.PRIVATE).build());
 
 				methods.add(MethodSpec.methodBuilder(String.format("set%s", TextUtil.capitalize(property.getName())))
-						.addModifiers(Modifier.PUBLIC).addParameter(handler.getParameterizedType(), property.getName())
+						.addModifiers(Modifier.PUBLIC).addParameter(type, property.getName())
 						.addStatement("this.$L = $L", property.getName(), property.getName()).build());
 			}
 		}
@@ -284,23 +289,24 @@ public class EntityProcessor extends AbstractProcessor {
 
 		for (EntityIndexPropertyMetadata property : properties) {
 
-			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes());
+			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes(), messager);
 
-			fields.add(FieldSpec.builder(handler.getParameterizedType(), property.getName())
-					.addModifiers(Modifier.PRIVATE).build());
+			TypeName type = handler.getType();
 
-			if (handler.isBoolean()) {
+			fields.add(FieldSpec.builder(type, property.getName()).addModifiers(Modifier.PRIVATE).build());
+
+			if (type.equals(CodeGenTypeUtil.BOOLEAN_TYPE_NAME)) {
 				methods.add(MethodSpec.methodBuilder(String.format("is%s", TextUtil.capitalize(property.getName())))
-						.addModifiers(Modifier.PUBLIC).returns(handler.getParameterizedType())
-						.addStatement("return $L", property.getName()).build());
+						.addModifiers(Modifier.PUBLIC).returns(type).addStatement("return $L", property.getName())
+						.build());
 			} else {
 				methods.add(MethodSpec.methodBuilder(String.format("get%s", TextUtil.capitalize(property.getName())))
-						.addModifiers(Modifier.PUBLIC).returns(handler.getParameterizedType())
-						.addStatement("return $L", property.getName()).build());
+						.addModifiers(Modifier.PUBLIC).returns(type).addStatement("return $L", property.getName())
+						.build());
 			}
 
 			methods.add(MethodSpec.methodBuilder(String.format("set%s", TextUtil.capitalize(property.getName())))
-					.addModifiers(Modifier.PUBLIC).addParameter(handler.getParameterizedType(), property.getName())
+					.addModifiers(Modifier.PUBLIC).addParameter(type, property.getName())
 					.addStatement("this.$L = $L", property.getName(), property.getName()).build());
 		}
 
@@ -352,16 +358,16 @@ public class EntityProcessor extends AbstractProcessor {
 
 		for (EntityIndexPropertyMetadata property : properties) {
 
-			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes());
+			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes(), messager);
+
+			TypeName type = handler.getType();
 
 //			if (property.isFinal()) {
 //				codeBlockBuilder.addStatement("writers.put($T.$S, ($T value) -> {})",
-//						ClassName.bestGuess(TypeUtil.PROPERTY_TYPE_NAME), property.getName(),
-//						handler.getParameterizedType());
+//						ClassName.bestGuess(TypeUtil.PROPERTY_TYPE_NAME), property.getName(), type);
 //			} else {
 			codeBlockBuilder.addStatement("writers.put($T.$L, ($T value) -> $L = value)",
-					ClassName.bestGuess("Properties"), property.getName(),
-					handler.getType().isPrimitive() ? handler.getType().box() : handler.getParameterizedType(),
+					ClassName.bestGuess("Properties"), property.getName(), type.isPrimitive() ? type.box() : type,
 					property.getName());
 //			}
 		}
@@ -406,8 +412,6 @@ public class EntityProcessor extends AbstractProcessor {
 		}
 
 		for (EntityIndexPropertyMetadata property : properties) {
-
-			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes());
 
 			codeBlockBuilder.addStatement("readers.put($T.$L, () -> $L)", ClassName.bestGuess("Properties"),
 					property.getName(), property.getName());
@@ -479,21 +483,19 @@ public class EntityProcessor extends AbstractProcessor {
 
 		for (EntityIndexPropertyMetadata property : properties) {
 
-			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes());
+			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes(), messager);
 
-			fields.add(
-					FieldSpec
-							.builder(ParameterizedTypeName.get(ClassName.bestGuess(TypeUtil.PROPERTY_TYPE_NAME),
-									handler.getType().isPrimitive() ? handler.getType().box()
-											: handler.getParameterizedType()),
-									property.getName())
-							.addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-							.initializer("$T.of($S, new $T() {})", ClassName.bestGuess(TypeUtil.PROPERTY_TYPE_NAME),
-									property.getName(),
-									ParameterizedTypeName.get(ClassName.bestGuess(TypeUtil.TYPE_REFERENCE_TYPE_NAME),
-											handler.getType().isPrimitive() ? handler.getType().box()
-													: handler.getParameterizedType()))
-							.build());
+			TypeName type = handler.getType();
+
+			fields.add(FieldSpec
+					.builder(ParameterizedTypeName.get(ClassName.bestGuess(TypeUtil.PROPERTY_TYPE_NAME),
+							type.isPrimitive() ? type.box() : type), property.getName())
+					.addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+					.initializer("$T.of($S, new $T() {})", ClassName.bestGuess(TypeUtil.PROPERTY_TYPE_NAME),
+							property.getName(),
+							ParameterizedTypeName.get(ClassName.bestGuess(TypeUtil.TYPE_REFERENCE_TYPE_NAME),
+									type.isPrimitive() ? type.box() : type))
+					.build());
 
 			codeBlockBuilder.addStatement("values.add($L)", property.getName());
 		}

--- a/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/EntityProcessor.java
+++ b/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/EntityProcessor.java
@@ -367,8 +367,7 @@ public class EntityProcessor extends AbstractProcessor {
 //						ClassName.bestGuess(TypeUtil.PROPERTY_TYPE_NAME), property.getName(), type);
 //			} else {
 			codeBlockBuilder.addStatement("writers.put($T.$L, ($T value) -> $L = value)",
-					ClassName.bestGuess("Properties"), property.getName(), type.isPrimitive() ? type.box() : type,
-					property.getName());
+					ClassName.bestGuess("Properties"), property.getName(), type.box(), property.getName());
 //			}
 		}
 
@@ -487,15 +486,15 @@ public class EntityProcessor extends AbstractProcessor {
 
 			TypeName type = handler.getType();
 
-			fields.add(FieldSpec
-					.builder(ParameterizedTypeName.get(ClassName.bestGuess(TypeUtil.PROPERTY_TYPE_NAME),
-							type.isPrimitive() ? type.box() : type), property.getName())
-					.addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-					.initializer("$T.of($S, new $T() {})", ClassName.bestGuess(TypeUtil.PROPERTY_TYPE_NAME),
-							property.getName(),
-							ParameterizedTypeName.get(ClassName.bestGuess(TypeUtil.TYPE_REFERENCE_TYPE_NAME),
-									type.isPrimitive() ? type.box() : type))
-					.build());
+			fields.add(
+					FieldSpec
+							.builder(ParameterizedTypeName.get(ClassName.bestGuess(TypeUtil.PROPERTY_TYPE_NAME),
+									type.box()), property.getName())
+							.addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+							.initializer("$T.of($S, new $T() {})", ClassName.bestGuess(TypeUtil.PROPERTY_TYPE_NAME),
+									property.getName(), ParameterizedTypeName
+											.get(ClassName.bestGuess(TypeUtil.TYPE_REFERENCE_TYPE_NAME), type.box()))
+							.build());
 
 			codeBlockBuilder.addStatement("values.add($L)", property.getName());
 		}

--- a/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/EntityProcessor.java
+++ b/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/EntityProcessor.java
@@ -123,7 +123,7 @@ public class EntityProcessor extends AbstractProcessor {
 
 		for (EntityPropertyMetadata property : properties) {
 
-			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property.getType(), entity.getTypes());
+			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes());
 
 			if (handler.isBoolean()) {
 				methods.add(MethodSpec.methodBuilder(String.format("is%s", TextUtil.capitalize(property.getName())))
@@ -284,7 +284,7 @@ public class EntityProcessor extends AbstractProcessor {
 
 		for (EntityIndexPropertyMetadata property : properties) {
 
-			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property.getType(), entity.getTypes());
+			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes());
 
 			fields.add(FieldSpec.builder(handler.getParameterizedType(), property.getName())
 					.addModifiers(Modifier.PRIVATE).build());
@@ -352,7 +352,7 @@ public class EntityProcessor extends AbstractProcessor {
 
 		for (EntityIndexPropertyMetadata property : properties) {
 
-			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property.getType(), entity.getTypes());
+			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes());
 
 //			if (property.isFinal()) {
 //				codeBlockBuilder.addStatement("writers.put($T.$S, ($T value) -> {})",
@@ -407,7 +407,7 @@ public class EntityProcessor extends AbstractProcessor {
 
 		for (EntityIndexPropertyMetadata property : properties) {
 
-			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property.getType(), entity.getTypes());
+			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes());
 
 			codeBlockBuilder.addStatement("readers.put($T.$L, () -> $L)", ClassName.bestGuess("Properties"),
 					property.getName(), property.getName());
@@ -479,7 +479,7 @@ public class EntityProcessor extends AbstractProcessor {
 
 		for (EntityIndexPropertyMetadata property : properties) {
 
-			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property.getType(), entity.getTypes());
+			CodeGenTypeHandler handler = CodeGenTypeUtil.getTypeHandler(property, entity.getTypes());
 
 			fields.add(
 					FieldSpec

--- a/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/EntityPropertyMetadata.java
+++ b/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/EntityPropertyMetadata.java
@@ -35,11 +35,11 @@ public class EntityPropertyMetadata {
 
 	private String type;
 
+	private boolean reference;
+
 	private boolean list;
 
 	private boolean set;
-
-	private boolean reference;
 
 	private final Set<Attribute> attributes = new HashSet<>();
 
@@ -62,6 +62,10 @@ public class EntityPropertyMetadata {
 
 				type = ProcessorUtil.stringVisitor.visit(value);
 
+			} else if (key.getSimpleName().contentEquals("reference")) {
+
+				reference = ProcessorUtil.booleanVisitor.visit(value).booleanValue();
+
 			} else if (key.getSimpleName().contentEquals("list")) {
 
 				list = ProcessorUtil.booleanVisitor.visit(value).booleanValue();
@@ -69,10 +73,6 @@ public class EntityPropertyMetadata {
 			} else if (key.getSimpleName().contentEquals("set")) {
 
 				set = ProcessorUtil.booleanVisitor.visit(value).booleanValue();
-
-			} else if (key.getSimpleName().contentEquals("reference")) {
-
-				reference = ProcessorUtil.booleanVisitor.visit(value).booleanValue();
 
 			} else if (key.getSimpleName().contentEquals("attributes")) {
 
@@ -122,6 +122,10 @@ public class EntityPropertyMetadata {
 		return type;
 	}
 
+	public boolean isReference() {
+		return reference;
+	}
+
 	public boolean isList() {
 		return list;
 	}
@@ -130,17 +134,13 @@ public class EntityPropertyMetadata {
 		return set;
 	}
 
-	public boolean isReference() {
-		return reference;
-	}
-
 	public boolean isFinal() {
 		return attributes.contains(Attribute.FINAL);
 	}
 
 	@Override
 	public String toString() {
-		return "EntityPropertyMetadata [name=" + name + ", type=" + type + ", list=" + list + ", set=" + set
-				+ ", reference=" + reference + ", attributes=" + attributes + "]";
+		return "EntityPropertyMetadata [name=" + name + ", type=" + type + ", reference=" + reference + ", list=" + list
+				+ ", set=" + set + ", attributes=" + attributes + "]";
 	}
 }

--- a/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/util/CodeGenTypeUtil.java
+++ b/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/util/CodeGenTypeUtil.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 import com.ijioio.aes.annotation.Type;
 import com.ijioio.aes.annotation.processor.EntityIndexPropertyMetadata;
 import com.ijioio.aes.annotation.processor.EntityPropertyMetadata;
-import com.ijioio.aes.annotation.processor.ParameterMetadata;
+import com.ijioio.aes.annotation.processor.Messager;
 import com.ijioio.aes.annotation.processor.TypeMetadata;
 import com.squareup.javapoet.ArrayTypeName;
 import com.squareup.javapoet.ClassName;
@@ -198,151 +198,110 @@ public class CodeGenTypeUtil {
 		 * @return type name
 		 */
 		public TypeName getImplementationType();
-
-		/**
-		 * Returns list of parameters type names of the type.
-		 * 
-		 * @param wildcards indicating whether wildcards should be included or not
-		 * @return list of parameters type names
-		 */
-		public List<TypeName> getParameters(boolean wildcards);
-
-		public default TypeName getParameterizedType() {
-
-			TypeName type = getType();
-			List<TypeName> parameters = getParameters(true);
-
-			return parameters.size() > 0 ? ParameterizedTypeName.get((ClassName) type,
-					parameters.stream().toArray(size -> new TypeName[size])) : type;
-		}
-
-		public default TypeName getParameterizedImplementationType() {
-
-			TypeName type = getImplementationType();
-			List<TypeName> parameters = getParameters(false);
-
-			return parameters.size() > 0 ? ParameterizedTypeName.get((ClassName) type,
-					parameters.stream().toArray(size -> new TypeName[size])) : type;
-		}
-
-		public default boolean isBoolean() {
-			return getType() == BOOLEAN_TYPE_NAME;
-		}
 	}
 
-	public static TypeMetadata resolveType(EntityPropertyMetadata property, Map<String, TypeMetadata> types) {
+	public static CodeGenTypeHandler getTypeHandler(EntityPropertyMetadata property, Map<String, TypeMetadata> types,
+			Messager messager) {
 
-		return Optional.ofNullable(resolveType(types.get(property.getType()), types))
-				.orElse(TypeMetadata.of(property.getType(), property.getType(), property.isReference(),
-						property.isList(), property.isSet(), Collections.emptyList()));
-	}
-
-	public static TypeMetadata resolveType(EntityIndexPropertyMetadata property, Map<String, TypeMetadata> types) {
-
-		return Optional.ofNullable(resolveType(types.get(property.getType()), types))
-				.orElse(TypeMetadata.of(property.getType(), property.getType(), property.isReference(),
-						property.isList(), property.isSet(), Collections.emptyList()));
-	}
-
-	public static TypeMetadata resolveType(ParameterMetadata parameter, Map<String, TypeMetadata> types) {
-
-		return Optional.ofNullable(resolveType(types.get(parameter.getName()), types)).orElse(TypeMetadata
-				.of(parameter.getName(), parameter.getName(), false, false, false, Collections.emptyList()));
-	}
-
-	private static TypeMetadata resolveType(TypeMetadata type, Map<String, TypeMetadata> types) {
-
-		return Optional.ofNullable(type).map(item -> resolveType(types.get(item.getType()), types)).orElse(type);
-	}
-
-	public static CodeGenTypeHandler getTypeHandler(EntityPropertyMetadata property, Map<String, TypeMetadata> types) {
-
-		return getTypeHandler(resolveType(property, types), types);
+		return getTypeHandler(TypeMetadata.of(property.getName(), property.getType(), property.isReference(),
+				property.isList(), property.isSet(), Collections.emptyList()), types, messager);
 	}
 
 	public static CodeGenTypeHandler getTypeHandler(EntityIndexPropertyMetadata property,
-			Map<String, TypeMetadata> types) {
+			Map<String, TypeMetadata> types, Messager messager) {
 
-		return getTypeHandler(resolveType(property, types), types);
+		return getTypeHandler(TypeMetadata.of(property.getName(), property.getType(), property.isReference(),
+				property.isList(), property.isSet(), Collections.emptyList()), types, messager);
 	}
 
-	public static CodeGenTypeHandler getTypeHandler(TypeMetadata type, Map<String, TypeMetadata> types) {
-
-		String name = type.getType();
+	public static CodeGenTypeHandler getTypeHandler(TypeMetadata type, Map<String, TypeMetadata> types,
+			Messager messager) {
 
 		return new CodeGenTypeHandler() {
 
 			@Override
 			public TypeName getType() {
 
-				if (name.equals(Type.BOOLEAN) || name.equals(TypeUtil.BOOLEAN_TYPE_NAME)) {
-					return BOOLEAN_TYPE_NAME;
-				}
-
-				if (name.equals(Type.CHAR) || name.equals(TypeUtil.CHAR_TYPE_NAME)) {
-					return CHAR_TYPE_NAME;
-				}
-
-				if (name.equals(Type.BYTE) || name.equals(TypeUtil.BYTE_TYPE_NAME)) {
-					return BYTE_TYPE_NAME;
-				}
-
-				if (name.equals(Type.SHORT) || name.equals(TypeUtil.SHORT_TYPE_NAME)) {
-					return SHORT_TYPE_NAME;
-				}
-
-				if (name.equals(Type.INT) || name.equals(TypeUtil.INT_TYPE_NAME)) {
-					return INT_TYPE_NAME;
-				}
-
-				if (name.equals(Type.LONG) || name.equals(TypeUtil.LONG_TYPE_NAME)) {
-					return LONG_TYPE_NAME;
-				}
-
-				if (name.equals(Type.FLOAT) || name.equals(TypeUtil.FLOAT_TYPE_NAME)) {
-					return FLOAT_TYPE_NAME;
-				}
-
-				if (name.equals(Type.DOUBLE) || name.equals(TypeUtil.DOUBLE_TYPE_NAME)) {
-					return DOUBLE_TYPE_NAME;
-				}
+				String name = type.getType();
 
 				TypeName typeName = null;
 
-				if (name.equals(Type.BYTE_ARRAY) || name.equals(TypeUtil.BYTE_ARRAY_TYPE_NAME)) {
-					typeName = BYTE_ARRAY_TYPE_NAME;
-				} else if (name.equals(Type.STRING) || name.equals(TypeUtil.STRING_TYPE_NAME)) {
-					typeName = STRING_TYPE_NAME;
-				} else if (name.equals(Type.INSTANT) || name.equals(TypeUtil.INSTANT_TYPE_NAME)) {
-					typeName = INSTANT_TYPE_NAME;
-				} else if (name.equals(Type.LOCAL_DATE_TIME) || name.equals(TypeUtil.LOCAL_DATE_TIME_TYPE_NAME)) {
-					typeName = LOCAL_DATE_TIME_TYPE_NAME;
-				} else if (name.equals(Type.LOCAL_DATE) || name.equals(TypeUtil.LOCAL_DATE_TYPE_NAME)) {
-					typeName = LOCAL_DATE_TYPE_NAME;
-				} else if (name.equals(Type.LOCAL_TIME) || name.equals(TypeUtil.LOCAL_TIME_TYPE_NAME)) {
-					typeName = LOCAL_TIME_TYPE_NAME;
-				} else if (name.equals(Type.CLASS) || name.equals(TypeUtil.CLASS_TYPE_NAME)) {
-					typeName = CLASS_TYPE_NAME;
-				} else if (name.equals(Type.LIST) || name.equals(TypeUtil.LIST_TYPE_NAME)) {
-					typeName = LIST_TYPE_NAME;
-				} else if (name.equals(Type.SET) || name.equals(TypeUtil.SET_TYPE_NAME)) {
-					typeName = SET_TYPE_NAME;
-				} else if (name.equals(Type.MAP) || name.equals(TypeUtil.MAP_TYPE_NAME)) {
-					typeName = MAP_TYPE_NAME;
-				} else if (name.equals(Type.ENTITY_REFERENCE) || name.equals(TypeUtil.ENTITY_REFERENCE_TYPE_NAME)) {
-					typeName = ENTITY_REFERENCE_TYPE_NAME;
+				if (types.containsKey(name)) {
+
+					typeName = getTypeHandler(types.get(name), types, messager).getType();
+
 				} else {
-					typeName = ClassName.bestGuess(name);
+
+					if (name.equals(Type.BOOLEAN) || name.equals(TypeUtil.BOOLEAN_TYPE_NAME)) {
+						typeName = BOOLEAN_TYPE_NAME;
+					} else if (name.equals(Type.CHAR) || name.equals(TypeUtil.CHAR_TYPE_NAME)) {
+						typeName = CHAR_TYPE_NAME;
+					} else if (name.equals(Type.BYTE) || name.equals(TypeUtil.BYTE_TYPE_NAME)) {
+						typeName = BYTE_TYPE_NAME;
+					} else if (name.equals(Type.SHORT) || name.equals(TypeUtil.SHORT_TYPE_NAME)) {
+						typeName = SHORT_TYPE_NAME;
+					} else if (name.equals(Type.INT) || name.equals(TypeUtil.INT_TYPE_NAME)) {
+						typeName = INT_TYPE_NAME;
+					} else if (name.equals(Type.LONG) || name.equals(TypeUtil.LONG_TYPE_NAME)) {
+						typeName = LONG_TYPE_NAME;
+					} else if (name.equals(Type.FLOAT) || name.equals(TypeUtil.FLOAT_TYPE_NAME)) {
+						typeName = FLOAT_TYPE_NAME;
+					} else if (name.equals(Type.DOUBLE) || name.equals(TypeUtil.DOUBLE_TYPE_NAME)) {
+						typeName = DOUBLE_TYPE_NAME;
+					} else if (name.equals(Type.BYTE_ARRAY) || name.equals(TypeUtil.BYTE_ARRAY_TYPE_NAME)) {
+						typeName = BYTE_ARRAY_TYPE_NAME;
+					} else if (name.equals(Type.STRING) || name.equals(TypeUtil.STRING_TYPE_NAME)) {
+						typeName = STRING_TYPE_NAME;
+					} else if (name.equals(Type.INSTANT) || name.equals(TypeUtil.INSTANT_TYPE_NAME)) {
+						typeName = INSTANT_TYPE_NAME;
+					} else if (name.equals(Type.LOCAL_DATE_TIME) || name.equals(TypeUtil.LOCAL_DATE_TIME_TYPE_NAME)) {
+						typeName = LOCAL_DATE_TIME_TYPE_NAME;
+					} else if (name.equals(Type.LOCAL_DATE) || name.equals(TypeUtil.LOCAL_DATE_TYPE_NAME)) {
+						typeName = LOCAL_DATE_TYPE_NAME;
+					} else if (name.equals(Type.LOCAL_TIME) || name.equals(TypeUtil.LOCAL_TIME_TYPE_NAME)) {
+						typeName = LOCAL_TIME_TYPE_NAME;
+					} else if (name.equals(Type.CLASS) || name.equals(TypeUtil.CLASS_TYPE_NAME)) {
+						typeName = CLASS_TYPE_NAME;
+					} else if (name.equals(Type.LIST) || name.equals(TypeUtil.LIST_TYPE_NAME)) {
+						typeName = LIST_TYPE_NAME;
+					} else if (name.equals(Type.SET) || name.equals(TypeUtil.SET_TYPE_NAME)) {
+						typeName = SET_TYPE_NAME;
+					} else if (name.equals(Type.MAP) || name.equals(TypeUtil.MAP_TYPE_NAME)) {
+						typeName = MAP_TYPE_NAME;
+					} else if (name.equals(Type.ENTITY_REFERENCE) || name.equals(TypeUtil.ENTITY_REFERENCE_TYPE_NAME)) {
+						typeName = ENTITY_REFERENCE_TYPE_NAME;
+					} else {
+						typeName = ClassName.bestGuess(name);
+					}
+
+					if (!typeName.isPrimitive() && (typeName instanceof ClassName)) {
+
+						List<TypeName> parameters = type.getParameters().stream()
+								.map(item -> Optional
+										.of(getTypeHandler(TypeMetadata.of(item.getName(), item.getName(), false, false,
+												false, Collections.emptyList()), types, messager).getType())
+										.map(type -> item.isWildcard() ? WildcardTypeName.subtypeOf(type) : type).get())
+								.collect(Collectors.toList());
+
+						if (parameters.size() > 0) {
+
+							typeName = ParameterizedTypeName.get((ClassName) typeName,
+									parameters.stream().toArray(size -> new TypeName[size]));
+						}
+					}
 				}
 
-				if (type.isReference()) {
-					typeName = ParameterizedTypeName.get(ENTITY_REFERENCE_TYPE_NAME, typeName);
-				}
+				if (!typeName.isPrimitive()) {
 
-				if (type.isList()) {
-					typeName = ParameterizedTypeName.get(LIST_TYPE_NAME, typeName);
-				} else if (type.isSet()) {
-					typeName = ParameterizedTypeName.get(SET_TYPE_NAME, typeName);
+					if (type.isReference()) {
+						typeName = ParameterizedTypeName.get(ENTITY_REFERENCE_TYPE_NAME, typeName);
+					}
+
+					if (type.isList()) {
+						typeName = ParameterizedTypeName.get(LIST_TYPE_NAME, typeName);
+					} else if (type.isSet()) {
+						typeName = ParameterizedTypeName.get(SET_TYPE_NAME, typeName);
+					}
 				}
 
 				return typeName;
@@ -351,87 +310,37 @@ public class CodeGenTypeUtil {
 			@Override
 			public TypeName getImplementationType() {
 
-				if (name.equals(Type.BOOLEAN) || name.equals(TypeUtil.BOOLEAN_TYPE_NAME)) {
-					return BOOLEAN_TYPE_NAME;
-				}
+				TypeName typeName = getType();
 
-				if (name.equals(Type.CHAR) || name.equals(TypeUtil.CHAR_TYPE_NAME)) {
-					return CHAR_TYPE_NAME;
-				}
+				if (typeName instanceof ParameterizedTypeName) {
 
-				if (name.equals(Type.BYTE) || name.equals(TypeUtil.BYTE_TYPE_NAME)) {
-					return BYTE_TYPE_NAME;
-				}
+					ParameterizedTypeName parameterizedTypeName = (ParameterizedTypeName) typeName;
 
-				if (name.equals(Type.SHORT) || name.equals(TypeUtil.SHORT_TYPE_NAME)) {
-					return SHORT_TYPE_NAME;
-				}
+					if (parameterizedTypeName.rawType.equals(LIST_TYPE_NAME)) {
+						typeName = ParameterizedTypeName.get(ARRAY_LIST_TYPE_NAME, parameterizedTypeName.typeArguments
+								.toArray(new TypeName[parameterizedTypeName.typeArguments.size()]));
+					} else if (parameterizedTypeName.rawType.equals(SET_TYPE_NAME)) {
+						typeName = ParameterizedTypeName.get(LINKED_HASH_SET_TYPE_NAME,
+								parameterizedTypeName.typeArguments
+										.toArray(new TypeName[parameterizedTypeName.typeArguments.size()]));
+					} else if (parameterizedTypeName.rawType.equals(MAP_TYPE_NAME)) {
+						typeName = ParameterizedTypeName.get(LINKED_HASH_MAP_TYPE_NAME,
+								parameterizedTypeName.typeArguments
+										.toArray(new TypeName[parameterizedTypeName.typeArguments.size()]));
+					}
 
-				if (name.equals(Type.INT) || name.equals(TypeUtil.INT_TYPE_NAME)) {
-					return INT_TYPE_NAME;
-				}
-
-				if (name.equals(Type.LONG) || name.equals(TypeUtil.LONG_TYPE_NAME)) {
-					return LONG_TYPE_NAME;
-				}
-
-				if (name.equals(Type.FLOAT) || name.equals(TypeUtil.FLOAT_TYPE_NAME)) {
-					return FLOAT_TYPE_NAME;
-				}
-
-				if (name.equals(Type.DOUBLE) || name.equals(TypeUtil.DOUBLE_TYPE_NAME)) {
-					return DOUBLE_TYPE_NAME;
-				}
-
-				TypeName typeName = null;
-
-				if (name.equals(Type.BYTE_ARRAY) || name.equals(TypeUtil.BYTE_ARRAY_TYPE_NAME)) {
-					typeName = BYTE_ARRAY_TYPE_NAME;
-				} else if (name.equals(Type.STRING) || name.equals(TypeUtil.STRING_TYPE_NAME)) {
-					typeName = STRING_TYPE_NAME;
-				} else if (name.equals(Type.INSTANT) || name.equals(TypeUtil.INSTANT_TYPE_NAME)) {
-					typeName = INSTANT_TYPE_NAME;
-				} else if (name.equals(Type.LOCAL_DATE_TIME) || name.equals(TypeUtil.LOCAL_DATE_TIME_TYPE_NAME)) {
-					typeName = LOCAL_DATE_TIME_TYPE_NAME;
-				} else if (name.equals(Type.LOCAL_DATE) || name.equals(TypeUtil.LOCAL_DATE_TYPE_NAME)) {
-					typeName = LOCAL_DATE_TYPE_NAME;
-				} else if (name.equals(Type.LOCAL_TIME) || name.equals(TypeUtil.LOCAL_TIME_TYPE_NAME)) {
-					typeName = LOCAL_TIME_TYPE_NAME;
-				} else if (name.equals(Type.CLASS) || name.equals(TypeUtil.CLASS_TYPE_NAME)) {
-					typeName = CLASS_TYPE_NAME;
-				} else if (name.equals(Type.LIST) || name.equals(TypeUtil.LIST_TYPE_NAME)) {
-					typeName = type.isList() ? LIST_TYPE_NAME : ARRAY_LIST_TYPE_NAME;
-				} else if (name.equals(Type.SET) || name.equals(TypeUtil.SET_TYPE_NAME)) {
-					typeName = type.isSet() ? SET_TYPE_NAME : LINKED_HASH_SET_TYPE_NAME;
-				} else if (name.equals(Type.MAP) || name.equals(TypeUtil.MAP_TYPE_NAME)) {
-					typeName = LINKED_HASH_MAP_TYPE_NAME;
-				} else if (name.equals(Type.ENTITY_REFERENCE) || name.equals(TypeUtil.ENTITY_REFERENCE_TYPE_NAME)) {
-					typeName = ENTITY_REFERENCE_TYPE_NAME;
 				} else {
-					typeName = ClassName.bestGuess(name);
-				}
 
-				if (type.isReference()) {
-					typeName = ParameterizedTypeName.get(ENTITY_REFERENCE_TYPE_NAME, typeName);
-				}
-
-				if (type.isList()) {
-					typeName = ParameterizedTypeName.get(ARRAY_LIST_TYPE_NAME, typeName);
-				} else if (type.isSet()) {
-					typeName = ParameterizedTypeName.get(LINKED_HASH_SET_TYPE_NAME, typeName);
+					if (typeName.equals(LIST_TYPE_NAME)) {
+						typeName = ARRAY_LIST_TYPE_NAME;
+					} else if (typeName.equals(SET_TYPE_NAME)) {
+						typeName = LINKED_HASH_SET_TYPE_NAME;
+					} else if (typeName.equals(MAP_TYPE_NAME)) {
+						typeName = LINKED_HASH_MAP_TYPE_NAME;
+					}
 				}
 
 				return typeName;
-			}
-
-			@Override
-			public List<TypeName> getParameters(boolean wildcards) {
-
-				return type.getParameters().stream()
-						.map(item -> Optional.of(getTypeHandler(resolveType(item, types), types).getParameterizedType())
-								.map(type -> wildcards && item.isWildcard() ? WildcardTypeName.subtypeOf(type) : type)
-								.get())
-						.collect(Collectors.toList());
 			}
 		};
 	}

--- a/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/util/CodeGenTypeUtil.java
+++ b/aes-processor/src/main/java/com/ijioio/aes/annotation/processor/util/CodeGenTypeUtil.java
@@ -15,6 +15,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.ijioio.aes.annotation.Type;
+import com.ijioio.aes.annotation.processor.EntityIndexPropertyMetadata;
+import com.ijioio.aes.annotation.processor.EntityPropertyMetadata;
+import com.ijioio.aes.annotation.processor.ParameterMetadata;
 import com.ijioio.aes.annotation.processor.TypeMetadata;
 import com.squareup.javapoet.ArrayTypeName;
 import com.squareup.javapoet.ClassName;
@@ -68,113 +71,113 @@ public class CodeGenTypeUtil {
 	/**
 	 * Type name for byte array type.
 	 */
-	public static final TypeName BYTE_ARRAY_TYPE_NAME = ArrayTypeName.of(TypeName.BYTE);
+	public static final ArrayTypeName BYTE_ARRAY_TYPE_NAME = ArrayTypeName.of(TypeName.BYTE);
 
 	/**
 	 * Type name for {@link String} type.
 	 */
-	public static final TypeName STRING_TYPE_NAME = ClassName.get(String.class);
+	public static final ClassName STRING_TYPE_NAME = ClassName.get(String.class);
 
 	/**
 	 * Type name for {@link Instant} type.
 	 */
-	public static final TypeName INSTANT_TYPE_NAME = ClassName.get(Instant.class);
+	public static final ClassName INSTANT_TYPE_NAME = ClassName.get(Instant.class);
 
 	/**
 	 * Type name for {@link LocalDateTime} type.
 	 */
-	public static final TypeName LOCAL_DATE_TIME_TYPE_NAME = ClassName.get(LocalDateTime.class);
+	public static final ClassName LOCAL_DATE_TIME_TYPE_NAME = ClassName.get(LocalDateTime.class);
 
 	/**
 	 * Type name for {@link LocalDate} type.
 	 */
-	public static final TypeName LOCAL_DATE_TYPE_NAME = ClassName.get(LocalDate.class);
+	public static final ClassName LOCAL_DATE_TYPE_NAME = ClassName.get(LocalDate.class);
 
 	/**
 	 * Type name for {@link LocalTime} type.
 	 */
-	public static final TypeName LOCAL_TIME_TYPE_NAME = ClassName.get(LocalTime.class);
+	public static final ClassName LOCAL_TIME_TYPE_NAME = ClassName.get(LocalTime.class);
 
 	/**
 	 * Type name for {@link Class} type.
 	 */
-	public static final TypeName CLASS_TYPE_NAME = ClassName.get(Class.class);
+	public static final ClassName CLASS_TYPE_NAME = ClassName.get(Class.class);
 
 	/**
 	 * Type name for {@link List} type.
 	 */
-	public static final TypeName LIST_TYPE_NAME = ClassName.get(List.class);
+	public static final ClassName LIST_TYPE_NAME = ClassName.get(List.class);
 
 	/**
 	 * Type name for {@link Set} type.
 	 */
-	public static final TypeName SET_TYPE_NAME = ClassName.get(Set.class);
+	public static final ClassName SET_TYPE_NAME = ClassName.get(Set.class);
 
 	/**
 	 * Type name for {@link Map} type.
 	 */
-	public static final TypeName MAP_TYPE_NAME = ClassName.get(Map.class);
+	public static final ClassName MAP_TYPE_NAME = ClassName.get(Map.class);
 
 	/**
 	 * Type name for {@link ArrayList} type.
 	 */
-	public static final TypeName ARRAY_LIST_TYPE_NAME = ClassName.get(ArrayList.class);
+	public static final ClassName ARRAY_LIST_TYPE_NAME = ClassName.get(ArrayList.class);
 
 	/**
 	 * Type name for {@link LinkedHashSet} type.
 	 */
-	public static final TypeName LINKED_HASH_SET_TYPE_NAME = ClassName.get(LinkedHashSet.class);
+	public static final ClassName LINKED_HASH_SET_TYPE_NAME = ClassName.get(LinkedHashSet.class);
 
 	/**
 	 * Type name for {@link LinkedHashMap} type.
 	 */
-	public static final TypeName LINKED_HASH_MAP_TYPE_NAME = ClassName.get(LinkedHashMap.class);
+	public static final ClassName LINKED_HASH_MAP_TYPE_NAME = ClassName.get(LinkedHashMap.class);
 
 	/**
 	 * Type name for base entity type.
 	 */
-	public static final TypeName BASE_ENTITY_TYPE_NAME = ClassName.bestGuess("com.ijioio.aes.core.BaseEntity");
+	public static final ClassName BASE_ENTITY_TYPE_NAME = ClassName.bestGuess("com.ijioio.aes.core.BaseEntity");
 
 	/**
 	 * Type name for base entity index type.
 	 */
-	public static final TypeName BASE_ENTITY_INDEX_TYPE_NAME = ClassName
+	public static final ClassName BASE_ENTITY_INDEX_TYPE_NAME = ClassName
 			.bestGuess("com.ijioio.aes.core.BaseEntityIndex");
 
 	/**
 	 * Type name for entity reference type.
 	 */
-	public static final TypeName ENTITY_REFERENCE_TYPE_NAME = ClassName
+	public static final ClassName ENTITY_REFERENCE_TYPE_NAME = ClassName
 			.bestGuess("com.ijioio.aes.core.EntityReference");
 
 	/**
 	 * Type name for serialization context.
 	 */
-	public static final TypeName SERIALIZATION_CONTEXT_TYPE_NAME = ClassName
+	public static final ClassName SERIALIZATION_CONTEXT_TYPE_NAME = ClassName
 			.bestGuess("com.ijioio.aes.core.serialization.SerializationContext");
 
 	/**
 	 * Type name for serialization handler.
 	 */
-	public static final TypeName SERIALIZATION_HANDLER_TYPE_NAME = ClassName
+	public static final ClassName SERIALIZATION_HANDLER_TYPE_NAME = ClassName
 			.bestGuess("com.ijioio.aes.core.serialization.SerializationHandler");
 
 	/**
 	 * Type name for serialization exception.
 	 */
-	public static final TypeName SERIALIZATION_EXCEPTION_TYPE_NAME = ClassName
+	public static final ClassName SERIALIZATION_EXCEPTION_TYPE_NAME = ClassName
 			.bestGuess("com.ijioio.aes.core.serialization.SerializationException");
 
 	/**
 	 * Type name for serialization writer.
 	 */
-	public static final TypeName SERIALIZATION_WRITER_TYPE_NAME = ClassName
+	public static final ClassName SERIALIZATION_WRITER_TYPE_NAME = ClassName
 			.bestGuess("com.ijioio.aes.core.serialization.SerializationWriter");
 
 	/**
 	 * Type name for serialization reader.
 	 */
-	public static final TypeName SERIALIZATION_READER_TYPE_NAME = ClassName
+	public static final ClassName SERIALIZATION_READER_TYPE_NAME = ClassName
 			.bestGuess("com.ijioio.aes.core.serialization.SerializationReader");
 
 	/**
@@ -194,9 +197,7 @@ public class CodeGenTypeUtil {
 		 * 
 		 * @return type name
 		 */
-		public default TypeName getImplementationType() {
-			return getType();
-		}
+		public TypeName getImplementationType();
 
 		/**
 		 * Returns list of parameters type names of the type.
@@ -204,9 +205,7 @@ public class CodeGenTypeUtil {
 		 * @param wildcards indicating whether wildcards should be included or not
 		 * @return list of parameters type names
 		 */
-		public default List<TypeName> getParameters(boolean wildcards) {
-			return Collections.emptyList();
-		}
+		public List<TypeName> getParameters(boolean wildcards);
 
 		public default TypeName getParameterizedType() {
 
@@ -229,170 +228,26 @@ public class CodeGenTypeUtil {
 		public default boolean isBoolean() {
 			return getType() == BOOLEAN_TYPE_NAME;
 		}
-
-		public default boolean isReference() {
-			return getType() == ENTITY_REFERENCE_TYPE_NAME;
-		}
 	}
 
-	/**
-	 * Type handler of boolean type.
-	 */
-	public static final CodeGenTypeHandler BOOLEAN_TYPE_HANDLER = new CodeGenTypeHandler() {
+	public static TypeMetadata resolveType(EntityPropertyMetadata property, Map<String, TypeMetadata> types) {
 
-		@Override
-		public TypeName getType() {
-			return BOOLEAN_TYPE_NAME;
-		}
-	};
+		return Optional.ofNullable(resolveType(types.get(property.getType()), types))
+				.orElse(TypeMetadata.of(property.getType(), property.getType(), property.isReference(),
+						property.isList(), property.isSet(), Collections.emptyList()));
+	}
 
-	/**
-	 * Type handler of char type.
-	 */
-	public static final CodeGenTypeHandler CHAR_TYPE_HANDLER = new CodeGenTypeHandler() {
+	public static TypeMetadata resolveType(EntityIndexPropertyMetadata property, Map<String, TypeMetadata> types) {
 
-		@Override
-		public TypeName getType() {
-			return CHAR_TYPE_NAME;
-		}
-	};
+		return Optional.ofNullable(resolveType(types.get(property.getType()), types))
+				.orElse(TypeMetadata.of(property.getType(), property.getType(), property.isReference(),
+						property.isList(), property.isSet(), Collections.emptyList()));
+	}
 
-	/**
-	 * Type handler of byte type.
-	 */
-	public static final CodeGenTypeHandler BYTE_TYPE_HANDLER = new CodeGenTypeHandler() {
+	public static TypeMetadata resolveType(ParameterMetadata parameter, Map<String, TypeMetadata> types) {
 
-		@Override
-		public TypeName getType() {
-			return BYTE_TYPE_NAME;
-		}
-	};
-
-	/**
-	 * Type handler of short type.
-	 */
-	public static final CodeGenTypeHandler SHORT_TYPE_HANDLER = new CodeGenTypeHandler() {
-
-		@Override
-		public TypeName getType() {
-			return SHORT_TYPE_NAME;
-		}
-	};
-
-	/**
-	 * Type handler of int type.
-	 */
-	public static final CodeGenTypeHandler INT_TYPE_HANDLER = new CodeGenTypeHandler() {
-
-		@Override
-		public TypeName getType() {
-			return INT_TYPE_NAME;
-		}
-	};
-
-	/**
-	 * Type handler of long type.
-	 */
-	public static final CodeGenTypeHandler LONG_TYPE_HANDLER = new CodeGenTypeHandler() {
-
-		@Override
-		public TypeName getType() {
-			return LONG_TYPE_NAME;
-		}
-	};
-
-	/**
-	 * Type handler of float type.
-	 */
-	public static final CodeGenTypeHandler FLOAT_TYPE_HANDLER = new CodeGenTypeHandler() {
-
-		@Override
-		public TypeName getType() {
-			return FLOAT_TYPE_NAME;
-		}
-	};
-
-	/**
-	 * Type handler of double type.
-	 */
-	public static final CodeGenTypeHandler DOUBLE_TYPE_HANDLER = new CodeGenTypeHandler() {
-
-		@Override
-		public TypeName getType() {
-			return DOUBLE_TYPE_NAME;
-		}
-	};
-
-	/**
-	 * Type handler of byte array type.
-	 */
-	public static final CodeGenTypeHandler BYTE_ARRAY_TYPE_HANDLER = new CodeGenTypeHandler() {
-
-		@Override
-		public TypeName getType() {
-			return BYTE_ARRAY_TYPE_NAME;
-		}
-	};
-
-	/**
-	 * Type handler of {@link String} type.
-	 */
-	public static final CodeGenTypeHandler STRING_TYPE_HANDLER = new CodeGenTypeHandler() {
-
-		@Override
-		public TypeName getType() {
-			return STRING_TYPE_NAME;
-		}
-	};
-
-	/**
-	 * Type handler of {@link Instant} type.
-	 */
-	public static final CodeGenTypeHandler INSTANT_TYPE_HANDLER = new CodeGenTypeHandler() {
-
-		@Override
-		public TypeName getType() {
-			return INSTANT_TYPE_NAME;
-		}
-	};
-
-	/**
-	 * Type handler of {@link LocalDateTime} type.
-	 */
-	public static final CodeGenTypeHandler LOCAL_DATE_TIME_TYPE_HANDLER = new CodeGenTypeHandler() {
-
-		@Override
-		public TypeName getType() {
-			return LOCAL_DATE_TIME_TYPE_NAME;
-		}
-	};
-
-	/**
-	 * Type handler of {@link LocalDate} type.
-	 */
-	public static final CodeGenTypeHandler LOCAL_DATE_TYPE_HANDLER = new CodeGenTypeHandler() {
-
-		@Override
-		public TypeName getType() {
-			return LOCAL_DATE_TYPE_NAME;
-		}
-	};
-
-	/**
-	 * Type handler of {@link LocalTime} type.
-	 */
-	public static final CodeGenTypeHandler LOCAL_TIME_TYPE_HANDLER = new CodeGenTypeHandler() {
-
-		@Override
-		public TypeName getType() {
-			return LOCAL_TIME_TYPE_NAME;
-		}
-	};
-
-	public static TypeMetadata resolveType(String type, Map<String, TypeMetadata> types) {
-
-		return Optional.ofNullable(resolveType(types.get(type), types))
-				.orElse(TypeMetadata.of(type, type, Collections.emptyList()));
+		return Optional.ofNullable(resolveType(types.get(parameter.getName()), types)).orElse(TypeMetadata
+				.of(parameter.getName(), parameter.getName(), false, false, false, Collections.emptyList()));
 	}
 
 	private static TypeMetadata resolveType(TypeMetadata type, Map<String, TypeMetadata> types) {
@@ -400,123 +255,180 @@ public class CodeGenTypeUtil {
 		return Optional.ofNullable(type).map(item -> resolveType(types.get(item.getType()), types)).orElse(type);
 	}
 
-	public static CodeGenTypeHandler getTypeHandler(String type, Map<String, TypeMetadata> types) {
+	public static CodeGenTypeHandler getTypeHandler(EntityPropertyMetadata property, Map<String, TypeMetadata> types) {
 
-		return getTypeHandler(resolveType(type, types), types);
+		return getTypeHandler(resolveType(property, types), types);
+	}
+
+	public static CodeGenTypeHandler getTypeHandler(EntityIndexPropertyMetadata property,
+			Map<String, TypeMetadata> types) {
+
+		return getTypeHandler(resolveType(property, types), types);
 	}
 
 	public static CodeGenTypeHandler getTypeHandler(TypeMetadata type, Map<String, TypeMetadata> types) {
 
 		String name = type.getType();
 
-		if (name.equals(Type.BOOLEAN) || name.equals(TypeUtil.BOOLEAN_TYPE_NAME)) {
-			return BOOLEAN_TYPE_HANDLER;
-		}
-
-		if (name.equals(Type.CHAR) || name.equals(TypeUtil.CHAR_TYPE_NAME)) {
-			return CHAR_TYPE_HANDLER;
-		}
-
-		if (name.equals(Type.BYTE) || name.equals(TypeUtil.BYTE_TYPE_NAME)) {
-			return BYTE_TYPE_HANDLER;
-		}
-
-		if (name.equals(Type.SHORT) || name.equals(TypeUtil.SHORT_TYPE_NAME)) {
-			return SHORT_TYPE_HANDLER;
-		}
-
-		if (name.equals(Type.INT) || name.equals(TypeUtil.INT_TYPE_NAME)) {
-			return INT_TYPE_HANDLER;
-		}
-
-		if (name.equals(Type.LONG) || name.equals(TypeUtil.LONG_TYPE_NAME)) {
-			return LONG_TYPE_HANDLER;
-		}
-
-		if (name.equals(Type.FLOAT) || name.equals(TypeUtil.FLOAT_TYPE_NAME)) {
-			return FLOAT_TYPE_HANDLER;
-		}
-
-		if (name.equals(Type.DOUBLE) || name.equals(TypeUtil.DOUBLE_TYPE_NAME)) {
-			return DOUBLE_TYPE_HANDLER;
-		}
-
-		if (name.equals(Type.BYTE_ARRAY) || name.equals(TypeUtil.BYTE_ARRAY_TYPE_NAME)) {
-			return BYTE_ARRAY_TYPE_HANDLER;
-		}
-
-		if (name.equals(Type.STRING) || name.equals(TypeUtil.STRING_TYPE_NAME)) {
-			return STRING_TYPE_HANDLER;
-		}
-
-		if (name.equals(Type.INSTANT) || name.equals(TypeUtil.INSTANT_TYPE_NAME)) {
-			return INSTANT_TYPE_HANDLER;
-		}
-
-		if (name.equals(Type.LOCAL_DATE_TIME) || name.equals(TypeUtil.LOCAL_DATE_TIME_TYPE_NAME)) {
-			return LOCAL_DATE_TIME_TYPE_HANDLER;
-		}
-
-		if (name.equals(Type.LOCAL_DATE) || name.equals(TypeUtil.LOCAL_DATE_TYPE_NAME)) {
-			return LOCAL_DATE_TYPE_HANDLER;
-		}
-
-		if (name.equals(Type.LOCAL_TIME) || name.equals(TypeUtil.LOCAL_TIME_TYPE_NAME)) {
-			return LOCAL_TIME_TYPE_HANDLER;
-		}
-
 		return new CodeGenTypeHandler() {
 
 			@Override
 			public TypeName getType() {
 
-				if (name.equals(Type.CLASS) || name.equals(TypeUtil.CLASS_TYPE_NAME)) {
-					return CLASS_TYPE_NAME;
+				if (name.equals(Type.BOOLEAN) || name.equals(TypeUtil.BOOLEAN_TYPE_NAME)) {
+					return BOOLEAN_TYPE_NAME;
 				}
 
-				if (name.equals(Type.LIST) || name.equals(TypeUtil.LIST_TYPE_NAME)) {
-					return LIST_TYPE_NAME;
+				if (name.equals(Type.CHAR) || name.equals(TypeUtil.CHAR_TYPE_NAME)) {
+					return CHAR_TYPE_NAME;
 				}
 
-				if (name.equals(Type.SET) || name.equals(TypeUtil.SET_TYPE_NAME)) {
-					return SET_TYPE_NAME;
+				if (name.equals(Type.BYTE) || name.equals(TypeUtil.BYTE_TYPE_NAME)) {
+					return BYTE_TYPE_NAME;
 				}
 
-				if (name.equals(Type.MAP) || name.equals(TypeUtil.MAP_TYPE_NAME)) {
-					return MAP_TYPE_NAME;
+				if (name.equals(Type.SHORT) || name.equals(TypeUtil.SHORT_TYPE_NAME)) {
+					return SHORT_TYPE_NAME;
 				}
 
-				if (name.equals(Type.ENTITY_REFERENCE) || name.equals(TypeUtil.ENTITY_REFERENCE_TYPE_NAME)) {
-					return ENTITY_REFERENCE_TYPE_NAME;
+				if (name.equals(Type.INT) || name.equals(TypeUtil.INT_TYPE_NAME)) {
+					return INT_TYPE_NAME;
 				}
 
-				return ClassName.bestGuess(name);
+				if (name.equals(Type.LONG) || name.equals(TypeUtil.LONG_TYPE_NAME)) {
+					return LONG_TYPE_NAME;
+				}
+
+				if (name.equals(Type.FLOAT) || name.equals(TypeUtil.FLOAT_TYPE_NAME)) {
+					return FLOAT_TYPE_NAME;
+				}
+
+				if (name.equals(Type.DOUBLE) || name.equals(TypeUtil.DOUBLE_TYPE_NAME)) {
+					return DOUBLE_TYPE_NAME;
+				}
+
+				TypeName typeName = null;
+
+				if (name.equals(Type.BYTE_ARRAY) || name.equals(TypeUtil.BYTE_ARRAY_TYPE_NAME)) {
+					typeName = BYTE_ARRAY_TYPE_NAME;
+				} else if (name.equals(Type.STRING) || name.equals(TypeUtil.STRING_TYPE_NAME)) {
+					typeName = STRING_TYPE_NAME;
+				} else if (name.equals(Type.INSTANT) || name.equals(TypeUtil.INSTANT_TYPE_NAME)) {
+					typeName = INSTANT_TYPE_NAME;
+				} else if (name.equals(Type.LOCAL_DATE_TIME) || name.equals(TypeUtil.LOCAL_DATE_TIME_TYPE_NAME)) {
+					typeName = LOCAL_DATE_TIME_TYPE_NAME;
+				} else if (name.equals(Type.LOCAL_DATE) || name.equals(TypeUtil.LOCAL_DATE_TYPE_NAME)) {
+					typeName = LOCAL_DATE_TYPE_NAME;
+				} else if (name.equals(Type.LOCAL_TIME) || name.equals(TypeUtil.LOCAL_TIME_TYPE_NAME)) {
+					typeName = LOCAL_TIME_TYPE_NAME;
+				} else if (name.equals(Type.CLASS) || name.equals(TypeUtil.CLASS_TYPE_NAME)) {
+					typeName = CLASS_TYPE_NAME;
+				} else if (name.equals(Type.LIST) || name.equals(TypeUtil.LIST_TYPE_NAME)) {
+					typeName = LIST_TYPE_NAME;
+				} else if (name.equals(Type.SET) || name.equals(TypeUtil.SET_TYPE_NAME)) {
+					typeName = SET_TYPE_NAME;
+				} else if (name.equals(Type.MAP) || name.equals(TypeUtil.MAP_TYPE_NAME)) {
+					typeName = MAP_TYPE_NAME;
+				} else if (name.equals(Type.ENTITY_REFERENCE) || name.equals(TypeUtil.ENTITY_REFERENCE_TYPE_NAME)) {
+					typeName = ENTITY_REFERENCE_TYPE_NAME;
+				} else {
+					typeName = ClassName.bestGuess(name);
+				}
+
+				if (type.isReference()) {
+					typeName = ParameterizedTypeName.get(ENTITY_REFERENCE_TYPE_NAME, typeName);
+				}
+
+				if (type.isList()) {
+					typeName = ParameterizedTypeName.get(LIST_TYPE_NAME, typeName);
+				} else if (type.isSet()) {
+					typeName = ParameterizedTypeName.get(SET_TYPE_NAME, typeName);
+				}
+
+				return typeName;
 			}
 
 			@Override
 			public TypeName getImplementationType() {
 
-				if (name.equals(Type.LIST) || name.equals(TypeUtil.LIST_TYPE_NAME)) {
-					return ARRAY_LIST_TYPE_NAME;
+				if (name.equals(Type.BOOLEAN) || name.equals(TypeUtil.BOOLEAN_TYPE_NAME)) {
+					return BOOLEAN_TYPE_NAME;
 				}
 
-				if (name.equals(Type.SET) || name.equals(TypeUtil.SET_TYPE_NAME)) {
-					return LINKED_HASH_SET_TYPE_NAME;
+				if (name.equals(Type.CHAR) || name.equals(TypeUtil.CHAR_TYPE_NAME)) {
+					return CHAR_TYPE_NAME;
 				}
 
-				if (name.equals(Type.MAP) || name.equals(TypeUtil.MAP_TYPE_NAME)) {
-					return LINKED_HASH_MAP_TYPE_NAME;
+				if (name.equals(Type.BYTE) || name.equals(TypeUtil.BYTE_TYPE_NAME)) {
+					return BYTE_TYPE_NAME;
 				}
 
-				return CodeGenTypeHandler.super.getImplementationType();
+				if (name.equals(Type.SHORT) || name.equals(TypeUtil.SHORT_TYPE_NAME)) {
+					return SHORT_TYPE_NAME;
+				}
+
+				if (name.equals(Type.INT) || name.equals(TypeUtil.INT_TYPE_NAME)) {
+					return INT_TYPE_NAME;
+				}
+
+				if (name.equals(Type.LONG) || name.equals(TypeUtil.LONG_TYPE_NAME)) {
+					return LONG_TYPE_NAME;
+				}
+
+				if (name.equals(Type.FLOAT) || name.equals(TypeUtil.FLOAT_TYPE_NAME)) {
+					return FLOAT_TYPE_NAME;
+				}
+
+				if (name.equals(Type.DOUBLE) || name.equals(TypeUtil.DOUBLE_TYPE_NAME)) {
+					return DOUBLE_TYPE_NAME;
+				}
+
+				TypeName typeName = null;
+
+				if (name.equals(Type.BYTE_ARRAY) || name.equals(TypeUtil.BYTE_ARRAY_TYPE_NAME)) {
+					typeName = BYTE_ARRAY_TYPE_NAME;
+				} else if (name.equals(Type.STRING) || name.equals(TypeUtil.STRING_TYPE_NAME)) {
+					typeName = STRING_TYPE_NAME;
+				} else if (name.equals(Type.INSTANT) || name.equals(TypeUtil.INSTANT_TYPE_NAME)) {
+					typeName = INSTANT_TYPE_NAME;
+				} else if (name.equals(Type.LOCAL_DATE_TIME) || name.equals(TypeUtil.LOCAL_DATE_TIME_TYPE_NAME)) {
+					typeName = LOCAL_DATE_TIME_TYPE_NAME;
+				} else if (name.equals(Type.LOCAL_DATE) || name.equals(TypeUtil.LOCAL_DATE_TYPE_NAME)) {
+					typeName = LOCAL_DATE_TYPE_NAME;
+				} else if (name.equals(Type.LOCAL_TIME) || name.equals(TypeUtil.LOCAL_TIME_TYPE_NAME)) {
+					typeName = LOCAL_TIME_TYPE_NAME;
+				} else if (name.equals(Type.CLASS) || name.equals(TypeUtil.CLASS_TYPE_NAME)) {
+					typeName = CLASS_TYPE_NAME;
+				} else if (name.equals(Type.LIST) || name.equals(TypeUtil.LIST_TYPE_NAME)) {
+					typeName = type.isList() ? LIST_TYPE_NAME : ARRAY_LIST_TYPE_NAME;
+				} else if (name.equals(Type.SET) || name.equals(TypeUtil.SET_TYPE_NAME)) {
+					typeName = type.isSet() ? SET_TYPE_NAME : LINKED_HASH_SET_TYPE_NAME;
+				} else if (name.equals(Type.MAP) || name.equals(TypeUtil.MAP_TYPE_NAME)) {
+					typeName = LINKED_HASH_MAP_TYPE_NAME;
+				} else if (name.equals(Type.ENTITY_REFERENCE) || name.equals(TypeUtil.ENTITY_REFERENCE_TYPE_NAME)) {
+					typeName = ENTITY_REFERENCE_TYPE_NAME;
+				} else {
+					typeName = ClassName.bestGuess(name);
+				}
+
+				if (type.isReference()) {
+					typeName = ParameterizedTypeName.get(ENTITY_REFERENCE_TYPE_NAME, typeName);
+				}
+
+				if (type.isList()) {
+					typeName = ParameterizedTypeName.get(ARRAY_LIST_TYPE_NAME, typeName);
+				} else if (type.isSet()) {
+					typeName = ParameterizedTypeName.get(LINKED_HASH_SET_TYPE_NAME, typeName);
+				}
+
+				return typeName;
 			}
 
 			@Override
 			public List<TypeName> getParameters(boolean wildcards) {
 
 				return type.getParameters().stream()
-						.map(item -> Optional
-								.of(getTypeHandler(resolveType(item.getName(), types), types).getParameterizedType())
+						.map(item -> Optional.of(getTypeHandler(resolveType(item, types), types).getParameterizedType())
 								.map(type -> wildcards && item.isWildcard() ? WildcardTypeName.subtypeOf(type) : type)
 								.get())
 						.collect(Collectors.toList());

--- a/aes-sandbox/.factorypath
+++ b/aes-sandbox/.factorypath
@@ -1,4 +1,4 @@
 <factorypath>
-    <factorypathentry kind="EXTJAR" id="C:\eclipse-workspace\advanced-entity-storage\aes-processor\build\libs\aes-processor.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="PLUGIN" id="org.eclipse.jst.ws.annotations.core" enabled="false" runInBatchMode="false"/>
+    <factorypathentry kind="WKSPJAR" id="/aes-processor/build/libs/aes-processor.jar" enabled="true" runInBatchMode="false"/>
 </factorypath>

--- a/aes-sandbox/.factorypath
+++ b/aes-sandbox/.factorypath
@@ -1,4 +1,4 @@
 <factorypath>
-    <factorypathentry kind="PLUGIN" id="org.eclipse.jst.ws.annotations.core" enabled="false" runInBatchMode="false"/>
     <factorypathentry kind="WKSPJAR" id="/aes-processor/build/libs/aes-processor.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="PLUGIN" id="org.eclipse.jst.ws.annotations.core" enabled="false" runInBatchMode="false"/>
 </factorypath>


### PR DESCRIPTION
We should provide special flags to simplify property declaration for the following types:

- `java.util.List`
- `java.util.Set`
- `com.ijioio.aes.core.EntityReference`

See #100 